### PR TITLE
fix: Enable VSP port sharing for multi-worker deployments

### DIFF
--- a/docs/20-vsp-service-protocol.md
+++ b/docs/20-vsp-service-protocol.md
@@ -135,6 +135,45 @@ mesh = ServiceMesh(
 )
 ```
 
+## Multi-Worker Support
+
+VSP now supports running multiple workers on the same port using the `SO_REUSEPORT` socket option. This is essential when running Velithon applications with multiple worker processes.
+
+### Port Sharing Configuration
+
+```python
+from velithon.vsp import VSPManager
+
+# Create VSP manager with port sharing enabled (default)
+manager = VSPManager("service-name", num_workers=4)
+
+# Start server with port reuse (enabled by default)
+await manager.start_server("localhost", 8001, reuse_port=True)
+
+# Disable port reuse if needed (not recommended for multi-worker setups)
+await manager.start_server("localhost", 8001, reuse_port=False)
+```
+
+### Multi-Worker Example
+
+```python
+# This configuration allows multiple worker processes to share the same VSP port
+from velithon import Velithon
+from velithon.vsp import VSPManager
+
+app = Velithon()
+
+# VSP manager with port sharing support
+vsp_manager = VSPManager("web-service", num_workers=4)
+
+@vsp_manager.vsp_service("health")
+async def health_check() -> dict:
+    return {"status": "healthy"}
+
+# The application will automatically enable port reuse when starting VSP
+# This allows multiple workers to bind to the same VSP port
+```
+
 ## Advanced Usage
 
 ### Custom Load Balancing

--- a/examples/vsp_multiworker_example.py
+++ b/examples/vsp_multiworker_example.py
@@ -1,0 +1,167 @@
+"""
+Example demonstrating VSP multi-worker support with port sharing.
+
+This example shows how to run multiple VSP services on the same port
+using the SO_REUSEPORT socket option, which is essential for multi-worker
+Velithon applications.
+"""
+
+import asyncio
+import logging
+
+from velithon.vsp import VSPManager
+
+# Configure logging to see the server startup messages
+logging.basicConfig(level=logging.INFO)
+
+
+async def example_multi_worker_vsp():
+    """Demonstrate multiple VSP managers sharing the same port."""
+    # Create multiple VSP managers (simulating multiple workers)
+    worker1_manager = VSPManager("worker-1", num_workers=2)
+    worker2_manager = VSPManager("worker-2", num_workers=2)
+    
+    # Define services for each worker
+    @worker1_manager.vsp_service("worker1_info")
+    async def worker1_info() -> dict:
+        return {
+            "worker_id": 1,
+            "status": "healthy",
+            "services": ["worker1_info", "shared_health"]
+        }
+    
+    @worker1_manager.vsp_service("shared_health")
+    async def shared_health_worker1() -> dict:
+        return {"worker": 1, "health": "ok", "timestamp": asyncio.get_event_loop().time()}
+    
+    @worker2_manager.vsp_service("worker2_info")
+    async def worker2_info() -> dict:
+        return {
+            "worker_id": 2,
+            "status": "healthy", 
+            "services": ["worker2_info", "shared_health"]
+        }
+    
+    @worker2_manager.vsp_service("shared_health")
+    async def shared_health_worker2() -> dict:
+        return {"worker": 2, "health": "ok", "timestamp": asyncio.get_event_loop().time()}
+    
+    print("Starting multiple VSP servers on the same port...")
+    print("This demonstrates port sharing for multi-worker deployments.")
+    
+    # Start both servers on the same port - this works with reuse_port=True
+    tasks = []
+    
+    try:
+        # Worker 1 starts first
+        task1 = asyncio.create_task(
+            worker1_manager.start_server("127.0.0.1", 8010, reuse_port=True)
+        )
+        tasks.append(task1)
+        
+        # Give it a moment to start
+        await asyncio.sleep(0.1)
+        
+        # Worker 2 starts on the same port
+        task2 = asyncio.create_task(
+            worker2_manager.start_server("127.0.0.1", 8010, reuse_port=True)
+        )
+        tasks.append(task2)
+        
+        print("\n✅ Both VSP servers started successfully!")
+        print("📋 Key benefits of port sharing:")
+        print("   • Multiple worker processes can bind to the same port")
+        print("   • Load balancing is handled by the kernel (SO_REUSEPORT)")
+        print("   • Eliminates 'port already in use' errors in multi-worker setups")
+        print("   • Enables horizontal scaling of VSP services")
+        
+        print("\n🔗 Both services are now available on port 8010")
+        print("   • worker1_info and shared_health (from worker 1)")
+        print("   • worker2_info and shared_health (from worker 2)")
+        
+        # Let servers run for a few seconds
+        await asyncio.sleep(3)
+        
+    except Exception as e:
+        print(f"❌ Error: {e}")
+    finally:
+        # Clean shutdown
+        print("\n🛑 Shutting down servers...")
+        for task in tasks:
+            task.cancel()
+        
+        # Wait for tasks to complete cancellation
+        for task in tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        
+        print("✅ Servers shut down successfully")
+
+
+async def example_without_port_sharing():
+    """Show what happens without port sharing (for comparison)."""
+    print("\n" + "="*60)
+    print("COMPARISON: Without port sharing (reuse_port=False)")
+    print("="*60)
+    
+    manager1 = VSPManager("no-sharing-1", num_workers=1)
+    manager2 = VSPManager("no-sharing-2", num_workers=1)
+    
+    @manager1.vsp_service("test")
+    async def test1() -> dict:
+        return {"manager": 1}
+    
+    @manager2.vsp_service("test")
+    async def test2() -> dict:
+        return {"manager": 2}
+    
+    try:
+        # First server binds successfully
+        task1 = asyncio.create_task(
+            manager1.start_server("127.0.0.1", 8011, reuse_port=False)
+        )
+        await asyncio.sleep(0.1)
+        
+        print("✅ First server started successfully")
+        
+        # Second server should fail
+        print("⏳ Attempting to start second server on same port...")
+        await manager2.start_server("127.0.0.1", 8011, reuse_port=False)
+        
+    except OSError as e:
+        if "address already in use" in str(e).lower():
+            print(f"❌ Expected error: {e}")
+            print("💡 This is why port sharing (reuse_port=True) is important!")
+        else:
+            print(f"❌ Unexpected error: {e}")
+    finally:
+        task1.cancel()
+        try:
+            await task1
+        except asyncio.CancelledError:
+            pass
+
+
+async def main():
+    """Run the examples."""
+    print("🚀 VSP Multi-Worker Port Sharing Example")
+    print("="*50)
+    
+    # Show the working solution
+    await example_multi_worker_vsp()
+    
+    # Show what happens without port sharing
+    await example_without_port_sharing()
+    
+    print("\n📚 Summary:")
+    print("   • Use reuse_port=True (default) for multi-worker deployments")
+    print("   • This enables SO_REUSEPORT socket option")
+    print("   • Multiple processes can bind to the same port")
+    print("   • Kernel handles load balancing between processes")
+    print("   • Essential for production multi-worker Velithon applications")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_vsp_multiworker.py
+++ b/tests/test_vsp_multiworker.py
@@ -1,0 +1,99 @@
+"""Test VSP multi-worker functionality."""
+
+import asyncio
+
+import pytest
+
+from velithon.vsp import VSPManager
+
+
+class TestVSPMultiWorker:
+    """Test VSP multi-worker functionality."""
+
+    @pytest.mark.asyncio
+    async def test_port_sharing_enabled(self):
+        """Test that multiple VSP managers can share the same port with reuse_port=True."""
+        manager1 = VSPManager("service1", num_workers=2)
+        manager2 = VSPManager("service2", num_workers=2)
+        
+        @manager1.vsp_service("test1")
+        async def test_endpoint1() -> dict:
+            return {"message": "from service1"}
+        
+        @manager2.vsp_service("test2")
+        async def test_endpoint2() -> dict:
+            return {"message": "from service2"}
+        
+        # Both should be able to bind to the same port with reuse_port=True
+        task1 = asyncio.create_task(
+            manager1.start_server("127.0.0.1", 8003, reuse_port=True)
+        )
+        await asyncio.sleep(0.1)  # Give first server time to bind
+        
+        task2 = asyncio.create_task(
+            manager2.start_server("127.0.0.1", 8003, reuse_port=True)
+        )
+        
+        # Wait to ensure both servers start
+        await asyncio.sleep(0.5)
+        
+        # Cleanup
+        task1.cancel()
+        task2.cancel()
+        
+        # Ensure tasks are properly cancelled
+        with pytest.raises(asyncio.CancelledError):
+            await task1
+        with pytest.raises(asyncio.CancelledError):
+            await task2
+
+    @pytest.mark.asyncio
+    async def test_port_sharing_disabled_fails(self):
+        """Test that multiple VSP managers cannot share the same port with reuse_port=False."""
+        manager1 = VSPManager("service1", num_workers=2)
+        manager2 = VSPManager("service2", num_workers=2)
+        
+        @manager1.vsp_service("test1")
+        async def test_endpoint1() -> dict:
+            return {"message": "from service1"}
+        
+        @manager2.vsp_service("test2")
+        async def test_endpoint2() -> dict:
+            return {"message": "from service2"}
+        
+        # First server should bind successfully
+        task1 = asyncio.create_task(
+            manager1.start_server("127.0.0.1", 8004, reuse_port=False)
+        )
+        await asyncio.sleep(0.1)  # Give first server time to bind
+        
+        # Second server should fail with "address already in use"
+        with pytest.raises(OSError) as exc_info:
+            await manager2.start_server("127.0.0.1", 8004, reuse_port=False)
+        
+        assert "address already in use" in str(exc_info.value).lower()
+        
+        # Cleanup
+        task1.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task1
+
+    @pytest.mark.asyncio
+    async def test_default_reuse_port_behavior(self):
+        """Test that reuse_port=True is the default behavior."""
+        manager = VSPManager("service", num_workers=2)
+        
+        @manager.vsp_service("test")
+        async def test_endpoint() -> dict:
+            return {"message": "test"}
+        
+        # Should work with default parameters (reuse_port=True by default)
+        task = asyncio.create_task(
+            manager.start_server("127.0.0.1", 8005)
+        )
+        await asyncio.sleep(0.1)
+        
+        # Cleanup
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/velithon/application.py
+++ b/velithon/application.py
@@ -760,7 +760,12 @@ class Velithon:
         # internal server startup
         if hasattr(self, "vsp_manager"):
             loop.create_task(
-                self.vsp_manager.start_server(self.vsp_host, self.vsp_port, loop=loop)
+                self.vsp_manager.start_server(
+                    self.vsp_host, 
+                    self.vsp_port, 
+                    loop=loop,
+                    reuse_port=True  # Enable port reuse for multi-worker support
+                )
             )
 
         # run all the startup functions from user setup


### PR DESCRIPTION
## Problem
When running Velithon applications with multiple workers, each worker process attempts to start a VSP server on the same port, resulting in "address already in use" errors. This prevents VSP services from working in production multi-worker deployments.

## Solution
This PR enables port sharing for VSP servers using the `SO_REUSEPORT` socket option, allowing multiple worker processes to bind to the same port. The kernel handles load balancing between the processes.

## Changes
- **Core Fix**: Added `reuse_port=True` parameter to `VSPManager.start_server()` method
- **Application Integration**: Updated `application.py` to enable port reuse by default for VSP servers
- **Backward Compatibility**: The change is backward compatible - `reuse_port` defaults to `True` but can be disabled if needed
- **Documentation**: Added comprehensive documentation about multi-worker support and port sharing
- **Testing**: Added comprehensive test suite for multi-worker VSP functionality
- **Example**: Added working example demonstrating VSP multi-worker port sharing

## Key Benefits
- ✅ Eliminates "address already in use" errors in multi-worker setups
- ✅ Enables horizontal scaling of VSP services
- ✅ Kernel-level load balancing between worker processes
- ✅ Essential for production multi-worker Velithon applications
- ✅ Backward compatible - existing code continues to work

## Testing
- All existing tests pass
- New comprehensive test suite for multi-worker functionality
- Manual testing with multiple VSP managers on same port
- Example application demonstrates the fix in action

## Files Changed
- `velithon/vsp/manager.py` - Added port sharing support
- `velithon/application.py` - Enable port reuse by default
- `docs/20-vsp-service-protocol.md` - Updated documentation
- `tests/test_vsp_multiworker.py` - New test suite
- `examples/vsp_multiworker_example.py` - Working example

## Backward Compatibility
This change is fully backward compatible. Existing code will work without modification and benefit from the improved multi-worker support.

Resolves the VSP multi-worker port binding issue.