### PR TITLE
Fix: Apply path prefix to routes in Router.__init__

### DIFF
--- a/tests/test_router_path.py
+++ b/tests/test_router_path.py
@@ -4,7 +4,7 @@ Test for Router path parameter functionality.
 
 from velithon import Velithon
 from velithon.responses import JSONResponse
-from velithon.routing import Router
+from velithon.routing import Route, Router
 
 
 def test_router_with_path_parameter():
@@ -115,6 +115,34 @@ def test_nested_router_paths():
     assert routes[0].path == '/api/v1/sub/endpoint'
 
 
+def test_router_init_with_routes_and_path():
+    """Test that Router __init__ applies path prefix to existing routes."""
+
+    def get_profile():
+        return JSONResponse({'message': 'profile'})
+
+    def get_settings():
+        return JSONResponse({'message': 'settings'})
+
+    # Create routes manually
+    profile_route = Route('/profile', get_profile, methods=['GET'])
+    settings_route = Route('/settings', get_settings, methods=['GET'])
+
+    # Create router with path prefix and existing routes
+    router = Router(path='/user', routes=[profile_route, settings_route])
+
+    # Check that path prefix was applied to existing routes
+    assert len(router.routes) == 2
+    assert router.routes[0].path == '/user/profile'
+    assert router.routes[1].path == '/user/settings'
+
+    # Check that the routes still have correct methods and endpoints
+    assert router.routes[0].methods == {'GET', 'HEAD'}
+    assert router.routes[1].methods == {'GET', 'HEAD'}
+    assert router.routes[0].endpoint == get_profile
+    assert router.routes[1].endpoint == get_settings
+
+
 if __name__ == '__main__':
     # Run basic tests
     test_router_with_path_parameter()
@@ -122,4 +150,5 @@ if __name__ == '__main__':
     test_application_add_router()
     test_router_with_no_path()
     test_nested_router_paths()
+    test_router_init_with_routes_and_path()
     print('All tests passed!')


### PR DESCRIPTION
## Problem

The Router class had an issue where the path prefix was not being applied to routes passed via the `routes` parameter in the `__init__` constructor. This meant that:

```python
# This worked correctly:
router = Router(path="/user")
router.add_api_route("/profile", handler)  # Result: /user/profile ✅

# But this did NOT work:
router = Router(path="/user", routes=[Route("/profile", handler)])  # Result: /profile ❌
```

## Solution

Fixed the `Router.__init__` method to properly apply the path prefix to all routes passed via the `routes` parameter.

### Changes Made

1. **Enhanced Router.__init__**: Modified the constructor to iterate through provided routes and apply the path prefix using the existing `_get_full_path()` method.

2. **Route Type Support**: Added proper handling for both HTTP routes and WebSocket routes when applying path prefixes.

3. **Comprehensive Testing**: Added `test_router_init_with_routes_and_path()` to ensure the fix works correctly.

### Technical Details

The fix creates new route instances with the prefixed paths while preserving all original route attributes (methods, middleware, OpenAPI settings, etc.):

```python
# For HTTP routes
full_path = self._get_full_path(route.path)
new_route = self.route_class(
    full_path,
    endpoint=route.endpoint,
    methods=getattr(route, 'methods', None),
    # ... other attributes preserved
)

# For WebSocket routes  
full_path = self._get_full_path(route.path)
new_route = WebSocketRoute(
    full_path,
    endpoint=route.endpoint,
    name=getattr(route, 'name', None),
)
```

## Testing

- ✅ All existing tests pass
- ✅ New test specifically covers the fixed scenario
- ✅ Verified both HTTP and WebSocket route support
- ✅ Tested with multiple routes in constructor
- ✅ Confirmed no regressions in existing functionality

## Files Changed

- `velithon/routing.py`: Fixed Router.__init__ method
- `tests/test_router_path.py`: Added comprehensive test coverage

## Before vs After

**Before:**
```python
router = Router(path="/user", routes=[Route("/profile", handler)])
# Result: route.path = "/profile" ❌
```

**After:**
```python
router = Router(path="/user", routes=[Route("/profile", handler)]) 
# Result: route.path = "/user/profile" ✅
```

This fix ensures consistent behavior across all methods of adding routes to a Router with a path prefix.