### PR TITLE
feat: add response_data property to Protocol class for tracking response content

### DIFF
--- a/velithon/datastructures.py
+++ b/velithon/datastructures.py
@@ -90,6 +90,7 @@ class Protocol:
     __slots__ = (
         '_headers',
         '_protocol',
+        '_response_data',
         '_status_code',
     )
 
@@ -97,6 +98,11 @@ class Protocol:
         self._protocol = protocol
         self._status_code = 200
         self._headers = []
+        self._response_data = []
+
+    @property
+    def response_data(self) -> list[bytes]:
+        return self._response_data
 
     async def __call__(self, *args, **kwds) -> bytes:
         return await self._protocol(*args, **kwds)
@@ -115,11 +121,13 @@ class Protocol:
         self._status_code = status
         self._headers.extend(headers)
         self._protocol.response_empty(status, self._headers)
+        self._response_data.append(b"")
 
     def response_str(self, status: int, headers: tuple[str, str], body: str) -> None:
         self._status_code = status
         self._headers.extend(headers)
         self._protocol.response_str(status, self._headers, body)
+        self._response_data.append(body.encode("utf-8"))
 
     def response_bytes(
         self, status: int, headers: tuple[str, str], body: bytes
@@ -127,6 +135,7 @@ class Protocol:
         self._status_code = status
         self._headers.extend(headers)
         self._protocol.response_bytes(status, self._headers, body)
+        self._response_data.append(body)
 
     def response_file(
         self, status: int, headers: tuple[str, str], file: typing.Any
@@ -134,6 +143,7 @@ class Protocol:
         self._status_code = status
         self._headers.extend(headers)
         self._protocol.response_file(status, self._headers, file)
+        self._response_data.append(file)
 
     def response_stream(self, status: int, headers: tuple[str, str]) -> typing.Any:
         self._status_code = status


### PR DESCRIPTION
This pull request introduces enhancements to the `Protocol` class in `velithon/datastructures.py`, focusing on tracking response data for various response types. The changes include adding a `_response_data` attribute, exposing it via a new `response_data` property, and updating response methods to append relevant data to `_response_data`.

### Enhancements to response data tracking:

* [`velithon/datastructures.py`](diffhunk://#diff-abfdaaee070d5a87d77e0fd535d2d59fbd13c520000ee319ff2286782859bce3R93-R105): Added a `_response_data` attribute to the `Protocol` class to store response data for all response types. This attribute is initialized as an empty list in the constructor.
* [`velithon/datastructures.py`](diffhunk://#diff-abfdaaee070d5a87d77e0fd535d2d59fbd13c520000ee319ff2286782859bce3R93-R105): Added a `response_data` property to allow external access to the `_response_data` attribute, returning it as a list of bytes.

### Updates to response methods:

* [`velithon/datastructures.py`](diffhunk://#diff-abfdaaee070d5a87d77e0fd535d2d59fbd13c520000ee319ff2286782859bce3R124-R146): Updated the `response_empty`, `response_str`, `response_bytes`, `response_file`, and `response_stream` methods to append the respective response data (e.g., empty bytes, encoded strings, raw bytes, or file objects) to `_response_data`. This ensures all response data is consistently tracked.