### PR TITLE
feat: Enhance parameter handling with alias support for Query, Header, and Cookie types

### DIFF
--- a/velithon/params/params.py
+++ b/velithon/params/params.py
@@ -181,7 +181,9 @@ class Query(Param):
         examples: list[Any] | None = None,
         include_in_schema: bool = True,
         json_schema_extra: dict[str, Any] | None = None,
+        convert_underscores: bool = True,
     ):
+        self.convert_underscores = convert_underscores
         super().__init__(
             default=default,
             default_factory=default_factory,
@@ -305,7 +307,9 @@ class Cookie(Param):
         examples: list[Any] | None = None,
         include_in_schema: bool = True,
         json_schema_extra: dict[str, Any] | None = None,
+        convert_underscores: bool = True,
     ):
+        self.convert_underscores = convert_underscores
         super().__init__(
             default=default,
             default_factory=default_factory,


### PR DESCRIPTION
This pull request introduces several enhancements to the `velithon` library, focusing on improved parameter alias handling, support for additional parameter types, and enhanced parsing logic. The most notable changes include the addition of cookie parameter support, alias resolution for parameter names, and updates to the parsing logic to handle aliases effectively.

### Parameter alias handling:

* [`velithon/openapi/docs.py`](diffhunk://#diff-2dbbf80ef48edcc3601b8c87cffccde91f4e21fe0b1679f804e919e5f9d444b6L18-R33): Added `_get_param_name_for_docs` to resolve parameter aliases, including auto-generated aliases by converting underscores to hyphens for certain parameter types. Updated `process_model_params` to use this alias resolution logic when generating documentation. [[1]](diffhunk://#diff-2dbbf80ef48edcc3601b8c87cffccde91f4e21fe0b1679f804e919e5f9d444b6L18-R33) [[2]](diffhunk://#diff-2dbbf80ef48edcc3601b8c87cffccde91f4e21fe0b1679f804e919e5f9d444b6R356-R362) [[3]](diffhunk://#diff-2dbbf80ef48edcc3601b8c87cffccde91f4e21fe0b1679f804e919e5f9d444b6R387-R415)

### Support for additional parameter types:

* [`velithon/params/params.py`](diffhunk://#diff-7a52f967bc1ecc402cc0e0382b948bebb3b48f9b1d34259bd71d491396626d26R184-R186): Introduced a `convert_underscores` attribute to parameter types for handling automatic alias generation. Added support for `Cookie` and `Header` parameters. [[1]](diffhunk://#diff-7a52f967bc1ecc402cc0e0382b948bebb3b48f9b1d34259bd71d491396626d26R184-R186) [[2]](diffhunk://#diff-7a52f967bc1ecc402cc0e0382b948bebb3b48f9b1d34259bd71d491396626d26R310-R312)
* [`velithon/params/parser.py`](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001L21-R29): Added support for `Cookie` and `Header` parameters in the `_fetch_data` method and updated the `_resolve_param_metadata` method to include these parameter types. [[1]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001L21-R29) [[2]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001R105-R106) [[3]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001L340-R405)

### Enhanced parsing logic:

* [`velithon/params/parser.py`](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001R134-R160): Added `_get_param_value_with_alias` to handle parameter value retrieval using explicit aliases, original names, or auto-generated aliases. Updated methods like `_parse_primitive`, `_parse_list`, `_parse_special`, and `_get_file` to use this alias resolution logic. [[1]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001R134-R160) [[2]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001R192-R195) [[3]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001L221-R261) [[4]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001R313) [[5]](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001L292-R343)
* [`velithon/params/parser.py`](diffhunk://#diff-ef81d6671de6e9738bce59b65682898df825371825056acb6d87495880ab0001L448-R515): Modified `resolve` to pass `param_metadata` to handlers that support alias resolution.