### PR TITLE
feat: Implement Rust-based header initialization for improved response performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod routing;
 mod templates;
 mod formparsers;
 mod event;
+mod responses;
 
 /// Velithon Rust Extensions
 /// High-performance Rust implementations for critical Velithon components
@@ -54,6 +55,9 @@ fn _velithon(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Register event handling system
     event::register_events(m.py(), m)?;
+
+    // Register response handling system
+    responses::register_responses(m.py(), m)?;
     
     Ok(())
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,0 +1,60 @@
+use pyo3::prelude::*;
+use std::collections::HashMap;
+
+#[pyfunction]
+fn header_init(
+    body_length: usize,
+    status_code: u16,
+    media_type: Option<String>,
+    charset: String,
+    provided_headers: Option<HashMap<String, String>>,
+) -> PyResult<Vec<(String, String)>> {
+    let mut headers = Vec::new();
+    let mut has_content_length = false;
+    let mut has_content_type = false;
+    
+    // Process existing headers
+    if let Some(header_dict) = provided_headers {
+        headers.reserve(header_dict.len() + 3);
+        
+        for (key, value) in header_dict {
+            let key_lower = key.to_lowercase();
+            
+            if key_lower == "content-length" {
+                has_content_length = true;
+            } else if key_lower == "content-type" {
+                has_content_type = true;
+            }
+            
+            headers.push((key_lower, value));
+        }
+    }
+    
+    // Add content-length if needed
+    if !has_content_length && 
+       body_length > 0 && 
+       !(status_code < 200 || status_code == 204 || status_code == 304) {
+        headers.push(("content-length".to_string(), body_length.to_string()));
+    }
+    
+    // Add content-type if needed
+    if !has_content_type {
+        if let Some(mut media_type) = media_type {
+            if media_type.starts_with("text/") && !media_type.to_lowercase().contains("charset=") {
+                media_type.push_str(&format!("; charset={}", charset));
+            }
+            headers.push(("content-type".to_string(), media_type));
+        }
+    }
+    
+    // Always add server header
+    headers.push(("server".to_string(), "velithon".to_string()));
+    
+    Ok(headers)
+}
+
+/// Register response functions and classes with Python module
+pub fn register_responses(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(header_init, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces a high-performance Rust implementation for HTTP response header initialization in the Velithon framework, replacing the previous Python logic. The new Rust code is exposed to Python and integrated into the base response class, improving efficiency for header processing.

**Integration of Rust-based response header initialization:**

* Added a new Rust module `responses` with a `header_init` function that constructs HTTP response headers efficiently, handling content length, content type, and server headers, and exposed it to Python via PyO3.
* Registered the `responses` module and its functions in the Rust extension initialization (`src/lib.rs`). [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R26) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R59-R61)

**Python-side changes to use Rust implementation:**

* Updated the Python base response class (`velithon/responses/base.py`) to use the Rust `header_init` function for header initialization, replacing the previous pure Python implementation.
* Documented the use of the Rust implementation in the response class docstring.