### PR TITLE
Update dependencies and refactor async executor methods

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -120,34 +120,34 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "24.10.0"
+version = "25.1.0"
 description = "The uncompromising code formatter."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
-    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
-    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
-    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
-    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
-    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
-    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
-    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
-    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
-    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
-    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
-    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
-    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
-    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
-    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
-    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
-    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
-    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
-    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
-    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
-    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
-    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
+    {file = "black-25.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32"},
+    {file = "black-25.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da"},
+    {file = "black-25.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7"},
+    {file = "black-25.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9"},
+    {file = "black-25.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0"},
+    {file = "black-25.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299"},
+    {file = "black-25.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096"},
+    {file = "black-25.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2"},
+    {file = "black-25.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b"},
+    {file = "black-25.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc"},
+    {file = "black-25.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f"},
+    {file = "black-25.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba"},
+    {file = "black-25.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f"},
+    {file = "black-25.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3"},
+    {file = "black-25.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171"},
+    {file = "black-25.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18"},
+    {file = "black-25.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0"},
+    {file = "black-25.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"},
+    {file = "black-25.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e"},
+    {file = "black-25.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355"},
+    {file = "black-25.1.0-py3-none-any.whl", hash = "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717"},
+    {file = "black-25.1.0.tar.gz", hash = "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666"},
 ]
 
 [package.dependencies]
@@ -579,79 +579,100 @@ markers = {main = "platform_system == \"Windows\"", dev = "platform_system == \"
 
 [[package]]
 name = "coverage"
-version = "7.9.1"
+version = "7.10.6"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "coverage-7.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cc94d7c5e8423920787c33d811c0be67b7be83c705f001f7180c7b186dcf10ca"},
-    {file = "coverage-7.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:16aa0830d0c08a2c40c264cef801db8bc4fc0e1892782e45bcacbd5889270509"},
-    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf95981b126f23db63e9dbe4cf65bd71f9a6305696fa5e2262693bc4e2183f5b"},
-    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f05031cf21699785cd47cb7485f67df619e7bcdae38e0fde40d23d3d0210d3c3"},
-    {file = "coverage-7.9.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb4fbcab8764dc072cb651a4bcda4d11fb5658a1d8d68842a862a6610bd8cfa3"},
-    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0f16649a7330ec307942ed27d06ee7e7a38417144620bb3d6e9a18ded8a2d3e5"},
-    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:cea0a27a89e6432705fffc178064503508e3c0184b4f061700e771a09de58187"},
-    {file = "coverage-7.9.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e980b53a959fa53b6f05343afbd1e6f44a23ed6c23c4b4c56c6662bbb40c82ce"},
-    {file = "coverage-7.9.1-cp310-cp310-win32.whl", hash = "sha256:70760b4c5560be6ca70d11f8988ee6542b003f982b32f83d5ac0b72476607b70"},
-    {file = "coverage-7.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:a66e8f628b71f78c0e0342003d53b53101ba4e00ea8dabb799d9dba0abbbcebe"},
-    {file = "coverage-7.9.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:95c765060e65c692da2d2f51a9499c5e9f5cf5453aeaf1420e3fc847cc060582"},
-    {file = "coverage-7.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ba383dc6afd5ec5b7a0d0c23d38895db0e15bcba7fb0fa8901f245267ac30d86"},
-    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37ae0383f13cbdcf1e5e7014489b0d71cc0106458878ccde52e8a12ced4298ed"},
-    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:69aa417a030bf11ec46149636314c24c8d60fadb12fc0ee8f10fda0d918c879d"},
-    {file = "coverage-7.9.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a4be2a28656afe279b34d4f91c3e26eccf2f85500d4a4ff0b1f8b54bf807338"},
-    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:382e7ddd5289f140259b610e5f5c58f713d025cb2f66d0eb17e68d0a94278875"},
-    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e5532482344186c543c37bfad0ee6069e8ae4fc38d073b8bc836fc8f03c9e250"},
-    {file = "coverage-7.9.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a39d18b3f50cc121d0ce3838d32d58bd1d15dab89c910358ebefc3665712256c"},
-    {file = "coverage-7.9.1-cp311-cp311-win32.whl", hash = "sha256:dd24bd8d77c98557880def750782df77ab2b6885a18483dc8588792247174b32"},
-    {file = "coverage-7.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:6b55ad10a35a21b8015eabddc9ba31eb590f54adc9cd39bcf09ff5349fd52125"},
-    {file = "coverage-7.9.1-cp311-cp311-win_arm64.whl", hash = "sha256:6ad935f0016be24c0e97fc8c40c465f9c4b85cbbe6eac48934c0dc4d2568321e"},
-    {file = "coverage-7.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a8de12b4b87c20de895f10567639c0797b621b22897b0af3ce4b4e204a743626"},
-    {file = "coverage-7.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5add197315a054e92cee1b5f686a2bcba60c4c3e66ee3de77ace6c867bdee7cb"},
-    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:600a1d4106fe66f41e5d0136dfbc68fe7200a5cbe85610ddf094f8f22e1b0300"},
-    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a876e4c3e5a2a1715a6608906aa5a2e0475b9c0f68343c2ada98110512ab1d8"},
-    {file = "coverage-7.9.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81f34346dd63010453922c8e628a52ea2d2ccd73cb2487f7700ac531b247c8a5"},
-    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:888f8eee13f2377ce86d44f338968eedec3291876b0b8a7289247ba52cb984cd"},
-    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:9969ef1e69b8c8e1e70d591f91bbc37fc9a3621e447525d1602801a24ceda898"},
-    {file = "coverage-7.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:60c458224331ee3f1a5b472773e4a085cc27a86a0b48205409d364272d67140d"},
-    {file = "coverage-7.9.1-cp312-cp312-win32.whl", hash = "sha256:5f646a99a8c2b3ff4c6a6e081f78fad0dde275cd59f8f49dc4eab2e394332e74"},
-    {file = "coverage-7.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:30f445f85c353090b83e552dcbbdad3ec84c7967e108c3ae54556ca69955563e"},
-    {file = "coverage-7.9.1-cp312-cp312-win_arm64.whl", hash = "sha256:af41da5dca398d3474129c58cb2b106a5d93bbb196be0d307ac82311ca234342"},
-    {file = "coverage-7.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:31324f18d5969feef7344a932c32428a2d1a3e50b15a6404e97cba1cc9b2c631"},
-    {file = "coverage-7.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0c804506d624e8a20fb3108764c52e0eef664e29d21692afa375e0dd98dc384f"},
-    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef64c27bc40189f36fcc50c3fb8f16ccda73b6a0b80d9bd6e6ce4cffcd810bbd"},
-    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4fe2348cc6ec372e25adec0219ee2334a68d2f5222e0cba9c0d613394e12d86"},
-    {file = "coverage-7.9.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34ed2186fe52fcc24d4561041979a0dec69adae7bce2ae8d1c49eace13e55c43"},
-    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:25308bd3d00d5eedd5ae7d4357161f4df743e3c0240fa773ee1b0f75e6c7c0f1"},
-    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:73e9439310f65d55a5a1e0564b48e34f5369bee943d72c88378f2d576f5a5751"},
-    {file = "coverage-7.9.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37ab6be0859141b53aa89412a82454b482c81cf750de4f29223d52268a86de67"},
-    {file = "coverage-7.9.1-cp313-cp313-win32.whl", hash = "sha256:64bdd969456e2d02a8b08aa047a92d269c7ac1f47e0c977675d550c9a0863643"},
-    {file = "coverage-7.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:be9e3f68ca9edb897c2184ad0eee815c635565dbe7a0e7e814dc1f7cbab92c0a"},
-    {file = "coverage-7.9.1-cp313-cp313-win_arm64.whl", hash = "sha256:1c503289ffef1d5105d91bbb4d62cbe4b14bec4d13ca225f9c73cde9bb46207d"},
-    {file = "coverage-7.9.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0b3496922cb5f4215bf5caaef4cf12364a26b0be82e9ed6d050f3352cf2d7ef0"},
-    {file = "coverage-7.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9565c3ab1c93310569ec0d86b017f128f027cab0b622b7af288696d7ed43a16d"},
-    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2241ad5dbf79ae1d9c08fe52b36d03ca122fb9ac6bca0f34439e99f8327ac89f"},
-    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bb5838701ca68b10ebc0937dbd0eb81974bac54447c55cd58dea5bca8451029"},
-    {file = "coverage-7.9.1-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b30a25f814591a8c0c5372c11ac8967f669b97444c47fd794926e175c4047ece"},
-    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2d04b16a6062516df97969f1ae7efd0de9c31eb6ebdceaa0d213b21c0ca1a683"},
-    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7931b9e249edefb07cd6ae10c702788546341d5fe44db5b6108a25da4dca513f"},
-    {file = "coverage-7.9.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:52e92b01041151bf607ee858e5a56c62d4b70f4dac85b8c8cb7fb8a351ab2c10"},
-    {file = "coverage-7.9.1-cp313-cp313t-win32.whl", hash = "sha256:684e2110ed84fd1ca5f40e89aa44adf1729dc85444004111aa01866507adf363"},
-    {file = "coverage-7.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:437c576979e4db840539674e68c84b3cda82bc824dd138d56bead1435f1cb5d7"},
-    {file = "coverage-7.9.1-cp313-cp313t-win_arm64.whl", hash = "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c"},
-    {file = "coverage-7.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6f424507f57878e424d9a95dc4ead3fbdd72fd201e404e861e465f28ea469951"},
-    {file = "coverage-7.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:535fde4001b2783ac80865d90e7cc7798b6b126f4cd8a8c54acfe76804e54e58"},
-    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02532fd3290bb8fa6bec876520842428e2a6ed6c27014eca81b031c2d30e3f71"},
-    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:56f5eb308b17bca3bbff810f55ee26d51926d9f89ba92707ee41d3c061257e55"},
-    {file = "coverage-7.9.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfa447506c1a52271f1b0de3f42ea0fa14676052549095e378d5bff1c505ff7b"},
-    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:9ca8e220006966b4a7b68e8984a6aee645a0384b0769e829ba60281fe61ec4f7"},
-    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:49f1d0788ba5b7ba65933f3a18864117c6506619f5ca80326b478f72acf3f385"},
-    {file = "coverage-7.9.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:68cd53aec6f45b8e4724c0950ce86eacb775c6be01ce6e3669fe4f3a21e768ed"},
-    {file = "coverage-7.9.1-cp39-cp39-win32.whl", hash = "sha256:95335095b6c7b1cc14c3f3f17d5452ce677e8490d101698562b2ffcacc304c8d"},
-    {file = "coverage-7.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:e1b5191d1648acc439b24721caab2fd0c86679d8549ed2c84d5a7ec1bedcc244"},
-    {file = "coverage-7.9.1-pp39.pp310.pp311-none-any.whl", hash = "sha256:db0f04118d1db74db6c9e1cb1898532c7dcc220f1d2718f058601f7c3f499514"},
-    {file = "coverage-7.9.1-py3-none-any.whl", hash = "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c"},
-    {file = "coverage-7.9.1.tar.gz", hash = "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec"},
+    {file = "coverage-7.10.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:70e7bfbd57126b5554aa482691145f798d7df77489a177a6bef80de78860a356"},
+    {file = "coverage-7.10.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e41be6f0f19da64af13403e52f2dec38bbc2937af54df8ecef10850ff8d35301"},
+    {file = "coverage-7.10.6-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c61fc91ab80b23f5fddbee342d19662f3d3328173229caded831aa0bd7595460"},
+    {file = "coverage-7.10.6-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:10356fdd33a7cc06e8051413140bbdc6f972137508a3572e3f59f805cd2832fd"},
+    {file = "coverage-7.10.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80b1695cf7c5ebe7b44bf2521221b9bb8cdf69b1f24231149a7e3eb1ae5fa2fb"},
+    {file = "coverage-7.10.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2e4c33e6378b9d52d3454bd08847a8651f4ed23ddbb4a0520227bd346382bbc6"},
+    {file = "coverage-7.10.6-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c8a3ec16e34ef980a46f60dc6ad86ec60f763c3f2fa0db6d261e6e754f72e945"},
+    {file = "coverage-7.10.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7d79dabc0a56f5af990cc6da9ad1e40766e82773c075f09cc571e2076fef882e"},
+    {file = "coverage-7.10.6-cp310-cp310-win32.whl", hash = "sha256:86b9b59f2b16e981906e9d6383eb6446d5b46c278460ae2c36487667717eccf1"},
+    {file = "coverage-7.10.6-cp310-cp310-win_amd64.whl", hash = "sha256:e132b9152749bd33534e5bd8565c7576f135f157b4029b975e15ee184325f528"},
+    {file = "coverage-7.10.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c706db3cabb7ceef779de68270150665e710b46d56372455cd741184f3868d8f"},
+    {file = "coverage-7.10.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8e0c38dc289e0508ef68ec95834cb5d2e96fdbe792eaccaa1bccac3966bbadcc"},
+    {file = "coverage-7.10.6-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:752a3005a1ded28f2f3a6e8787e24f28d6abe176ca64677bcd8d53d6fe2ec08a"},
+    {file = "coverage-7.10.6-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:689920ecfd60f992cafca4f5477d55720466ad2c7fa29bb56ac8d44a1ac2b47a"},
+    {file = "coverage-7.10.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ec98435796d2624d6905820a42f82149ee9fc4f2d45c2c5bc5a44481cc50db62"},
+    {file = "coverage-7.10.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b37201ce4a458c7a758ecc4efa92fa8ed783c66e0fa3c42ae19fc454a0792153"},
+    {file = "coverage-7.10.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:2904271c80898663c810a6b067920a61dd8d38341244a3605bd31ab55250dad5"},
+    {file = "coverage-7.10.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5aea98383463d6e1fa4e95416d8de66f2d0cb588774ee20ae1b28df826bcb619"},
+    {file = "coverage-7.10.6-cp311-cp311-win32.whl", hash = "sha256:e3fb1fa01d3598002777dd259c0c2e6d9d5e10e7222976fc8e03992f972a2cba"},
+    {file = "coverage-7.10.6-cp311-cp311-win_amd64.whl", hash = "sha256:f35ed9d945bece26553d5b4c8630453169672bea0050a564456eb88bdffd927e"},
+    {file = "coverage-7.10.6-cp311-cp311-win_arm64.whl", hash = "sha256:99e1a305c7765631d74b98bf7dbf54eeea931f975e80f115437d23848ee8c27c"},
+    {file = "coverage-7.10.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5b2dd6059938063a2c9fee1af729d4f2af28fd1a545e9b7652861f0d752ebcea"},
+    {file = "coverage-7.10.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:388d80e56191bf846c485c14ae2bc8898aa3124d9d35903fef7d907780477634"},
+    {file = "coverage-7.10.6-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:90cb5b1a4670662719591aa92d0095bb41714970c0b065b02a2610172dbf0af6"},
+    {file = "coverage-7.10.6-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:961834e2f2b863a0e14260a9a273aff07ff7818ab6e66d2addf5628590c628f9"},
+    {file = "coverage-7.10.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bf9a19f5012dab774628491659646335b1928cfc931bf8d97b0d5918dd58033c"},
+    {file = "coverage-7.10.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:99c4283e2a0e147b9c9cc6bc9c96124de9419d6044837e9799763a0e29a7321a"},
+    {file = "coverage-7.10.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:282b1b20f45df57cc508c1e033403f02283adfb67d4c9c35a90281d81e5c52c5"},
+    {file = "coverage-7.10.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8cdbe264f11afd69841bd8c0d83ca10b5b32853263ee62e6ac6a0ab63895f972"},
+    {file = "coverage-7.10.6-cp312-cp312-win32.whl", hash = "sha256:a517feaf3a0a3eca1ee985d8373135cfdedfbba3882a5eab4362bda7c7cf518d"},
+    {file = "coverage-7.10.6-cp312-cp312-win_amd64.whl", hash = "sha256:856986eadf41f52b214176d894a7de05331117f6035a28ac0016c0f63d887629"},
+    {file = "coverage-7.10.6-cp312-cp312-win_arm64.whl", hash = "sha256:acf36b8268785aad739443fa2780c16260ee3fa09d12b3a70f772ef100939d80"},
+    {file = "coverage-7.10.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ffea0575345e9ee0144dfe5701aa17f3ba546f8c3bb48db62ae101afb740e7d6"},
+    {file = "coverage-7.10.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:95d91d7317cde40a1c249d6b7382750b7e6d86fad9d8eaf4fa3f8f44cf171e80"},
+    {file = "coverage-7.10.6-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3e23dd5408fe71a356b41baa82892772a4cefcf758f2ca3383d2aa39e1b7a003"},
+    {file = "coverage-7.10.6-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0f3f56e4cb573755e96a16501a98bf211f100463d70275759e73f3cbc00d4f27"},
+    {file = "coverage-7.10.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:db4a1d897bbbe7339946ffa2fe60c10cc81c43fab8b062d3fcb84188688174a4"},
+    {file = "coverage-7.10.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d8fd7879082953c156d5b13c74aa6cca37f6a6f4747b39538504c3f9c63d043d"},
+    {file = "coverage-7.10.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:28395ca3f71cd103b8c116333fa9db867f3a3e1ad6a084aa3725ae002b6583bc"},
+    {file = "coverage-7.10.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:61c950fc33d29c91b9e18540e1aed7d9f6787cc870a3e4032493bbbe641d12fc"},
+    {file = "coverage-7.10.6-cp313-cp313-win32.whl", hash = "sha256:160c00a5e6b6bdf4e5984b0ef21fc860bc94416c41b7df4d63f536d17c38902e"},
+    {file = "coverage-7.10.6-cp313-cp313-win_amd64.whl", hash = "sha256:628055297f3e2aa181464c3808402887643405573eb3d9de060d81531fa79d32"},
+    {file = "coverage-7.10.6-cp313-cp313-win_arm64.whl", hash = "sha256:df4ec1f8540b0bcbe26ca7dd0f541847cc8a108b35596f9f91f59f0c060bfdd2"},
+    {file = "coverage-7.10.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:c9a8b7a34a4de3ed987f636f71881cd3b8339f61118b1aa311fbda12741bff0b"},
+    {file = "coverage-7.10.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8dd5af36092430c2b075cee966719898f2ae87b636cefb85a653f1d0ba5d5393"},
+    {file = "coverage-7.10.6-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b0353b0f0850d49ada66fdd7d0c7cdb0f86b900bb9e367024fd14a60cecc1e27"},
+    {file = "coverage-7.10.6-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d6b9ae13d5d3e8aeca9ca94198aa7b3ebbc5acfada557d724f2a1f03d2c0b0df"},
+    {file = "coverage-7.10.6-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:675824a363cc05781b1527b39dc2587b8984965834a748177ee3c37b64ffeafb"},
+    {file = "coverage-7.10.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:692d70ea725f471a547c305f0d0fc6a73480c62fb0da726370c088ab21aed282"},
+    {file = "coverage-7.10.6-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:851430a9a361c7a8484a36126d1d0ff8d529d97385eacc8dfdc9bfc8c2d2cbe4"},
+    {file = "coverage-7.10.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d9369a23186d189b2fc95cc08b8160ba242057e887d766864f7adf3c46b2df21"},
+    {file = "coverage-7.10.6-cp313-cp313t-win32.whl", hash = "sha256:92be86fcb125e9bda0da7806afd29a3fd33fdf58fba5d60318399adf40bf37d0"},
+    {file = "coverage-7.10.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6b3039e2ca459a70c79523d39347d83b73f2f06af5624905eba7ec34d64d80b5"},
+    {file = "coverage-7.10.6-cp313-cp313t-win_arm64.whl", hash = "sha256:3fb99d0786fe17b228eab663d16bee2288e8724d26a199c29325aac4b0319b9b"},
+    {file = "coverage-7.10.6-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:6008a021907be8c4c02f37cdc3ffb258493bdebfeaf9a839f9e71dfdc47b018e"},
+    {file = "coverage-7.10.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5e75e37f23eb144e78940b40395b42f2321951206a4f50e23cfd6e8a198d3ceb"},
+    {file = "coverage-7.10.6-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0f7cb359a448e043c576f0da00aa8bfd796a01b06aa610ca453d4dde09cc1034"},
+    {file = "coverage-7.10.6-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c68018e4fc4e14b5668f1353b41ccf4bc83ba355f0e1b3836861c6f042d89ac1"},
+    {file = "coverage-7.10.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cd4b2b0707fc55afa160cd5fc33b27ccbf75ca11d81f4ec9863d5793fc6df56a"},
+    {file = "coverage-7.10.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cec13817a651f8804a86e4f79d815b3b28472c910e099e4d5a0e8a3b6a1d4cb"},
+    {file = "coverage-7.10.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f2a6a8e06bbda06f78739f40bfb56c45d14eb8249d0f0ea6d4b3d48e1f7c695d"},
+    {file = "coverage-7.10.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:081b98395ced0d9bcf60ada7661a0b75f36b78b9d7e39ea0790bb4ed8da14747"},
+    {file = "coverage-7.10.6-cp314-cp314-win32.whl", hash = "sha256:6937347c5d7d069ee776b2bf4e1212f912a9f1f141a429c475e6089462fcecc5"},
+    {file = "coverage-7.10.6-cp314-cp314-win_amd64.whl", hash = "sha256:adec1d980fa07e60b6ef865f9e5410ba760e4e1d26f60f7e5772c73b9a5b0713"},
+    {file = "coverage-7.10.6-cp314-cp314-win_arm64.whl", hash = "sha256:a80f7aef9535442bdcf562e5a0d5a5538ce8abe6bb209cfbf170c462ac2c2a32"},
+    {file = "coverage-7.10.6-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:0de434f4fbbe5af4fa7989521c655c8c779afb61c53ab561b64dcee6149e4c65"},
+    {file = "coverage-7.10.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6e31b8155150c57e5ac43ccd289d079eb3f825187d7c66e755a055d2c85794c6"},
+    {file = "coverage-7.10.6-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:98cede73eb83c31e2118ae8d379c12e3e42736903a8afcca92a7218e1f2903b0"},
+    {file = "coverage-7.10.6-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f863c08f4ff6b64fa8045b1e3da480f5374779ef187f07b82e0538c68cb4ff8e"},
+    {file = "coverage-7.10.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b38261034fda87be356f2c3f42221fdb4171c3ce7658066ae449241485390d5"},
+    {file = "coverage-7.10.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e93b1476b79eae849dc3872faeb0bf7948fd9ea34869590bc16a2a00b9c82a7"},
+    {file = "coverage-7.10.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ff8a991f70f4c0cf53088abf1e3886edcc87d53004c7bb94e78650b4d3dac3b5"},
+    {file = "coverage-7.10.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ac765b026c9f33044419cbba1da913cfb82cca1b60598ac1c7a5ed6aac4621a0"},
+    {file = "coverage-7.10.6-cp314-cp314t-win32.whl", hash = "sha256:441c357d55f4936875636ef2cfb3bee36e466dcf50df9afbd398ce79dba1ebb7"},
+    {file = "coverage-7.10.6-cp314-cp314t-win_amd64.whl", hash = "sha256:073711de3181b2e204e4870ac83a7c4853115b42e9cd4d145f2231e12d670930"},
+    {file = "coverage-7.10.6-cp314-cp314t-win_arm64.whl", hash = "sha256:137921f2bac5559334ba66122b753db6dc5d1cf01eb7b64eb412bb0d064ef35b"},
+    {file = "coverage-7.10.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:90558c35af64971d65fbd935c32010f9a2f52776103a259f1dee865fe8259352"},
+    {file = "coverage-7.10.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8953746d371e5695405806c46d705a3cd170b9cc2b9f93953ad838f6c1e58612"},
+    {file = "coverage-7.10.6-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:c83f6afb480eae0313114297d29d7c295670a41c11b274e6bca0c64540c1ce7b"},
+    {file = "coverage-7.10.6-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7eb68d356ba0cc158ca535ce1381dbf2037fa8cb5b1ae5ddfc302e7317d04144"},
+    {file = "coverage-7.10.6-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5b15a87265e96307482746d86995f4bff282f14b027db75469c446da6127433b"},
+    {file = "coverage-7.10.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fc53ba868875bfbb66ee447d64d6413c2db91fddcfca57025a0e7ab5b07d5862"},
+    {file = "coverage-7.10.6-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:efeda443000aa23f276f4df973cb82beca682fd800bb119d19e80504ffe53ec2"},
+    {file = "coverage-7.10.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:9702b59d582ff1e184945d8b501ffdd08d2cee38d93a2206aa5f1365ce0b8d78"},
+    {file = "coverage-7.10.6-cp39-cp39-win32.whl", hash = "sha256:2195f8e16ba1a44651ca684db2ea2b2d4b5345da12f07d9c22a395202a05b23c"},
+    {file = "coverage-7.10.6-cp39-cp39-win_amd64.whl", hash = "sha256:f32ff80e7ef6a5b5b606ea69a36e97b219cd9dc799bcf2963018a4d8f788cfbf"},
+    {file = "coverage-7.10.6-py3-none-any.whl", hash = "sha256:92c4ecf6bf11b2e85fd4d8204814dc26e6a19f0c9d938c207c5cb0eadfcabbe3"},
+    {file = "coverage-7.10.6.tar.gz", hash = "sha256:f644a3ae5933a552a29dbb9aa2f90c677a875f80ebea028e5a52a4f429044b90"},
 ]
 
 [package.dependencies]
@@ -1005,18 +1026,19 @@ files = [
 
 [[package]]
 name = "isort"
-version = "5.13.2"
+version = "6.0.1"
 description = "A Python utility / library to sort Python imports."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 groups = ["dev"]
 files = [
-    {file = "isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"},
-    {file = "isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109"},
+    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
+    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
 ]
 
 [package.extras]
-colors = ["colorama (>=0.4.6)"]
+colors = ["colorama"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "jinja2"
@@ -1806,97 +1828,92 @@ test = ["pillow", "pytest", "ruff"]
 
 [[package]]
 name = "pyferris"
-version = "0.4.0"
+version = "0.5.2"
 description = "PyFerris is a high-performance parallel processing library for Python, powered by Rust and PyO3"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pyferris-0.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6272f434d8fb674d9f0d7de150369b0b9c8c63a1249eb2c445e9442bf452f3eb"},
-    {file = "pyferris-0.4.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:852c064f846a73405277992eafee8499334ec2675c7690c2b2813b4b88552b65"},
-    {file = "pyferris-0.4.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75afc06c92b6dd5da8b53778e6818b0e0a23ddde25fa2e128cea07a92abb3cb6"},
-    {file = "pyferris-0.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01472bd2164675361c02341d67cc86d45293d3cbe9cc13f8c135a8ccc9984a46"},
-    {file = "pyferris-0.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c61433f7a56b51f62a7528adff3c3d69a3776f214e58436a71d76919156468ab"},
-    {file = "pyferris-0.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17a3c9859d2f94219ce7872854a5429c47b22c4a522d03b14cd0e2c9fab8e0e9"},
-    {file = "pyferris-0.4.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7291e441e4588f9cc91e24991b109f4c6123705754a8968d7419fd67e7d2cf96"},
-    {file = "pyferris-0.4.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:b1ce69b3f5b92d1277cd4f05a961893bee96b4611c51f8808101080304d31f75"},
-    {file = "pyferris-0.4.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:57692d69c5ada4afb9eb78579c81db388e8278d3c4fbfa1ddf1fb4ae024a84d1"},
-    {file = "pyferris-0.4.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:331f6fa23ec5fa856dc97fcb0326eaa5f77226081d6f841b9f5534f994ed79e1"},
-    {file = "pyferris-0.4.0-cp310-cp310-win32.whl", hash = "sha256:63aba243aa003b98e785443205f36ec415aa220f8020e231266e4251f7652103"},
-    {file = "pyferris-0.4.0-cp310-cp310-win_amd64.whl", hash = "sha256:45383b6a51c9af1272cf4facb5b1c7671b55f343807ffd1c54f33880a3c37241"},
-    {file = "pyferris-0.4.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b61387e911102f18fd4e68aa1fe91d6ed6cea5e0e033ea133f357a1a2e226ca4"},
-    {file = "pyferris-0.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:117c7370fc956b523406e1fe349039d9dbf57bcc7992295fb9c13eb6cda211c2"},
-    {file = "pyferris-0.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48d7d8acbb345c61d8db0a30958cbe4c8f2e263c3b61a59db703ea05d4a29367"},
-    {file = "pyferris-0.4.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:003f6ab75bd1430f20bca6850c3c820ef267c72616476fac329820c44ef6e674"},
-    {file = "pyferris-0.4.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:21e96529a029dbc95aa9d22e2c73a9eb56f59e588e4f562dbd9be3a5b68dfe7c"},
-    {file = "pyferris-0.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3731b035beaed6bb63294c2268e6f565c74f35ae85627c6e34071bb453a59d1d"},
-    {file = "pyferris-0.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c58a3a3fe4ad5c8d9c6f4a61869a97aa88b6b731d40538cde9ffc6fef5eb8802"},
-    {file = "pyferris-0.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52e313ec97d595631ae57e0630e82a6e7306f9ab45055864f3521784d0a6f29a"},
-    {file = "pyferris-0.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9e6f36fda77559c1982de3166d88b5cd16cf7ed8e8ae3d5186dccdf1c035bbf7"},
-    {file = "pyferris-0.4.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:fe4c7e3ee27e5a989be5f608b90b96bb264023a6a440627d04e8b2c0aee58a90"},
-    {file = "pyferris-0.4.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:02168bc64f785162bf36a69a1d0e49115a8fafe8a34c1e0d16f1eb1d80c12330"},
-    {file = "pyferris-0.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:96bc51ad9e8063432390193aa592457e783aab06fcb1e1c13c14013dc28ea6ff"},
-    {file = "pyferris-0.4.0-cp311-cp311-win32.whl", hash = "sha256:710d9b04ef373db7c6c24c8ca87fe445cbb50df95cfd3f8f654a13b8f1bff391"},
-    {file = "pyferris-0.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:59dc805d4fa6b506f40fbfb8ca70a1f8452522bd20f8ce5be24fc62d68256ae9"},
-    {file = "pyferris-0.4.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0777a09a310cbd9c0996300620c4a19d9883236e6d027449f9720ce7ba55843d"},
-    {file = "pyferris-0.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0df9aa899b67ede6580bae86917f203ed867239b338fce9aba2a39d86c067c50"},
-    {file = "pyferris-0.4.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e75cbbd763a1a0d09c0597a52e6616aff776e1dcc92c25c6ab8eb06dc71dff9"},
-    {file = "pyferris-0.4.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2caf6b25e1f36afdb198871d63c67c4b680333418ff4711f92682a32dbb75089"},
-    {file = "pyferris-0.4.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c4fbe510ad4f4986658ecfce117a93b7b08a36e58c23db30b5a943038f4e34f7"},
-    {file = "pyferris-0.4.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:07068a00e118a77e75d14985e6b9e546dce7355111a03aaaf7faacc69a69d1a6"},
-    {file = "pyferris-0.4.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:818ad3ceaa41972f1dc72dfd9c84dbb9b35b752558fb89c546aea6f25d542bad"},
-    {file = "pyferris-0.4.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3c49621d6ca202cca82ec57c13d8e181264274125ce425ccfd003105be58121"},
-    {file = "pyferris-0.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e8e6d9fd53de4b46648573bd12126faaa0178cde3029d93b2280141ca6efae19"},
-    {file = "pyferris-0.4.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:bc3030712101bf9ffdb92f1e264997f255c9b24679771fdd07a76a5406659ffd"},
-    {file = "pyferris-0.4.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cd5519339f21418f05bde3be42e8b461d9bb6c5f374611a27fabd7933a6ec018"},
-    {file = "pyferris-0.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1e3256c33e0d79ac0ef06f98bfb7a07d49fd90840fea2fcb435effe0d49fe205"},
-    {file = "pyferris-0.4.0-cp312-cp312-win32.whl", hash = "sha256:b323ae3d25c9c61efae08b887e46d2e7b27d379a8b335230886d89665251673c"},
-    {file = "pyferris-0.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:edc3e036a90f01becc8f1e6505a4322fe43db50ca9af05e59e8cc222fe19f625"},
-    {file = "pyferris-0.4.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:018c0dc83205ce5a9243ad1d3602a6ed1e0fb26b7b31105995a64367c07cf365"},
-    {file = "pyferris-0.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c4b048a1ae325d364cfd8c23d79af8c8f5559862996538872352269cc03015c8"},
-    {file = "pyferris-0.4.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69ee8d72fab3994dc6e11684d995fb0c27787f6f45bca390a6a1c75a096b718a"},
-    {file = "pyferris-0.4.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da396b978238549a172dab1996ea69523d1139d4556b53c6703f692977ee4aa0"},
-    {file = "pyferris-0.4.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2209e494c2d936883a8a78b8b56e00961e5843f6c36e052b2687cb257e9170a8"},
-    {file = "pyferris-0.4.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc392f392ee0958fc31f3812bd538f81ebda41354c6e00f890d54c45431ee9a1"},
-    {file = "pyferris-0.4.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe78c370845dda194a831e6507957c46577103f19e3016bef71152415c477689"},
-    {file = "pyferris-0.4.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4295ef4a2c2c3766f811638ddfa40366a312f69ccca2f0a1511fe634e784d04a"},
-    {file = "pyferris-0.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e88ea0a95af73c0c8c366ff7c5c7f972a9de746443a8082afcc13cbcf8fe77a6"},
-    {file = "pyferris-0.4.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8eeea92edb6d58154c187255a44b1ad9cad29ede160bfe54d11453bbf9f5f070"},
-    {file = "pyferris-0.4.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:6df5efa48d2901c6bb518642b2dc2141543ab138cf895d83191466e890e5e89d"},
-    {file = "pyferris-0.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e31a187d71c62f568e194705840bdd5a53531107d632e63b59a8bd4bab25dc3f"},
-    {file = "pyferris-0.4.0-cp313-cp313-win32.whl", hash = "sha256:90eb92e3500d6b9e50380894f22c05504f5d49d121de2cae66d4dcfde665ca24"},
-    {file = "pyferris-0.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:16aaa27fe53f380569a084771b83acfcc0ba318dab7766dee3bd808b2a0fcdbb"},
-    {file = "pyferris-0.4.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:846afe105d5598e21a7dd0fee7c00c343b78e54196f7a56f6093662d15f63388"},
-    {file = "pyferris-0.4.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4fa0441ea36a9c85278620a0f527b63f67c38fceffca6061add1c07b9f2908f2"},
-    {file = "pyferris-0.4.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2736feb6a5630c41877a43988188fb227accdf14e31345015fe9a58b3b393263"},
-    {file = "pyferris-0.4.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf9780eb162d2ad5c0a0e63729a6bbdfb7d211c4cb5facd2188c4aa3faaa9d96"},
-    {file = "pyferris-0.4.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3a798f0058e470a4fa6685774e70f6ffacb0da42b0a08251d685cf05275c9ec2"},
-    {file = "pyferris-0.4.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:3c298f438f85455b9b5340bcdae241456e39f9120cf7bd832b3fa2fbfe09f112"},
-    {file = "pyferris-0.4.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1c68981d2cb7b9a85e13b9f49257a0a2c076e9362c734f50677968fe3a7b61dd"},
-    {file = "pyferris-0.4.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:00a1a848fccc6ee23cf451ae43a0af19dd740b67a9d5a52eb6ad9c3e1580789f"},
-    {file = "pyferris-0.4.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dae86ff5b3e663dfd734bf9d961ea33313b093f2bc8c3cb218e701fb1e5b56e0"},
-    {file = "pyferris-0.4.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:65b261449e35a06ced3c6250e34868e9f1f2cc26baeac8fc93bde6042e4a910f"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d043e5f716396d3e763e6ac4a7e70bcc15f1f5db7e9bf954c69a982cf8fa791e"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43c62e2633ffb7d8d1ba74be61b51c8950ed025775e534228a1b9b155fa41454"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f810b874a032eae4948b0e25bbbee91334668e995ba32f206c00892ffefb123c"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a777b0974d2123176add23e29cef1b333a8053f7b098fc117871ac44cd5505e"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f656942790cc5d78f1297d9d07540416cb968bc692921304867f99d2292a8caf"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c240faef6685c80d7b6707cc7cd3970c5eb466e48f0befb202815a79535f2cce"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:29fffb4499ae4c331debfbfb09c39f9a0adbc9eb6e5e31795aab3b3d6e00e916"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:b5037a9012c748b88627ebe86cd106de2a6653ffc542dc0e37d5148053879be7"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:bccbd447ddc1d1a16b17262d54170769ee66c8826563112603498fc439c3d13f"},
-    {file = "pyferris-0.4.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:efe7396c2519d4228dd3f6392d4b49b99797203abdbc08004801879c34081da3"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e21ad50ab75a1f03965fc479c79f6654f5bd31900efadd64e717f7b1ce03347f"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1f32f2ff23a64d2aa56029adf0f776e99c8bb968adc3c424f5ed1049c221e741"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:404bfc24cc0ce15e8c7ca9fe414e75945b7124fb4287a2e3098ef6b056b9b8f3"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c6d66b1b73193fa0a893f75848d325a083f30fa7e9fa5fb351c899d6c1ad6ca"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48aee3032aef1876cbd7f9ba0a07afec6ca183211d2a5265485e3dcd8b3b4148"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f66413a00bd4588b43acde98cdc738b01391c2e91b95337b0ad37aae6f378bd"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:a6fc4d028d575a65e8553cb7a9ac4ef5320b4fd40a1283055d6e25d69447fd2f"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:ad9f40c74d5d8b31e3b836856fddebea3f996064c9963fc7a8ccd00400a3740d"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:14f7e6871ef9c6a4d584615eff6f055fe10d95aeb971519df189dfa4439f9f05"},
-    {file = "pyferris-0.4.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:5e6a635893ee822e0c18b7250ed967fd804a3905ffdb49939fb243c66fc88d16"},
-    {file = "pyferris-0.4.0.tar.gz", hash = "sha256:3b60f1afd12bdebaafa693d628be45c41352d3e4b90caa6795e316d788abb54b"},
+    {file = "pyferris-0.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd5bc28722866ac631e0b15c2004ea017916458f71b6446fb5841de8ca3c74b"},
+    {file = "pyferris-0.5.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62beab65d8225ef4abb8fafdcf04970cd8bf4c7894b63900e2bada4912d3c9b1"},
+    {file = "pyferris-0.5.2-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:92ee6a88819244828740290419f19728bbd9b16a071de527a3e568079169e4ba"},
+    {file = "pyferris-0.5.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5457baeaa4d320c593d58f120f6d48b9a1589ed36093cef8fccd7b9821414b1c"},
+    {file = "pyferris-0.5.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ada92b645ef3d69cbcd1e06495d20f1203aa6d8e2bc0c8235ea9303c4119b71f"},
+    {file = "pyferris-0.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5be707e0e7fcd269aa626db22408b98f38cf0b08cdccd967d507641ef528f646"},
+    {file = "pyferris-0.5.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf890bbb93d1ab16a316bc689fd6812644d51cb446b4e9aa41cdd3fb7e8d774a"},
+    {file = "pyferris-0.5.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bae17ec20e149de4f8caac1e72394ea7cde0d41bf6cfc777b08d82baece29159"},
+    {file = "pyferris-0.5.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dae96aff0ff716be9c6161468a344159fda5847d82f323a3c1d5ac2c2bb884be"},
+    {file = "pyferris-0.5.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:04c2ec9d71b6704af8f81dc0b949cc7722beb85cfe7346bc9c01c8f9e5f94437"},
+    {file = "pyferris-0.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:260be61c07db09802a03669671d0335a16cdec656db608031c6475376131f090"},
+    {file = "pyferris-0.5.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:da3ef330bc474926df1509de4d491eebc6df0915f547cc06d3b9a524878804cd"},
+    {file = "pyferris-0.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1633ab67eec204230fb3a161e41cdeef77719d1508b3eab7fd9ddd733bd8d241"},
+    {file = "pyferris-0.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6c97b091cada375ec595ef53e30e92a236478faeb7d292489f1c973e23ff0f5"},
+    {file = "pyferris-0.5.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7cb367f36dd414b73cb0f5b55f5906ffd8000fb782d73b54408fca4b1788f2"},
+    {file = "pyferris-0.5.2-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a12738d81159e2af74fb08c1ecb5811addb752caeecf4e3c88757bfd6c72a111"},
+    {file = "pyferris-0.5.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:34cce3071f526560240b51e1a0f8d7f36d6d76bc6437e0c42e675516d6fd9c03"},
+    {file = "pyferris-0.5.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:41e560950af6d6aebf64c74ccfdfa57cb55eb6c7a41c384e19f5904b62ce0ce4"},
+    {file = "pyferris-0.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:259b3aeb67d8567dc524f3383bde8c7a0bd781b92e56cd80aac6dd3d278d7496"},
+    {file = "pyferris-0.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f7163a988a036ffc807c707cd789056281a8ee812a70647637fc7973fb1b73dc"},
+    {file = "pyferris-0.5.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:4a1791cd92b0651765b49b981156293e80001ef9ec279f2d0fc354b57497ee3f"},
+    {file = "pyferris-0.5.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:bd8a9e123e50729349bc84d425944cd8a6938a4887a483f78210fd410949142c"},
+    {file = "pyferris-0.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f41a849ba20daf93e1cbe2a3421e7f0d03274f11c43ea15b85ed40dabdad2877"},
+    {file = "pyferris-0.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:11916d567a8b25d50113641efaa63c17b6d715b4ed45d540a7626f0f8f4b79d0"},
+    {file = "pyferris-0.5.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:996563f16a634ab4b1adcaca8ad851cae0d757050d42f3269d616ac593f166bf"},
+    {file = "pyferris-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:539c1a0c892509f3137a5bc74ca2e2b10212449b5a91759c8b92932560395c9f"},
+    {file = "pyferris-0.5.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:204e9292b08de5b8e52dfd1ceab6daea911c00944193f724588ea785734d6ae8"},
+    {file = "pyferris-0.5.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0d8b48772ecb707f800c1e90d7bfb7ecae765e0ea6447c3726c2bf1f5c05e7be"},
+    {file = "pyferris-0.5.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3276b48683259f2a5c37f32ba024a74b21fb590ddd017ee519ce960b454dc32"},
+    {file = "pyferris-0.5.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c616835e07fe1ef51073cd1f1c4ce5332977caecfe07245ae5183fd907894001"},
+    {file = "pyferris-0.5.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5a97b210ea9ea572c9fa1d11fcffcfdd70db4ebf9f24d05db9deed2280573bae"},
+    {file = "pyferris-0.5.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab52e185201d67118f6cdf4d9b764fa0c32ed9b2f6d3129801139312048a90fb"},
+    {file = "pyferris-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:03e4288e1332f60079de32b3a855007a20cf066637d1d11de789cb892ea34ab0"},
+    {file = "pyferris-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:fb1bea722cb6a280a7c47299809666c8beeaf2777a343aeeafc73cb3c77da390"},
+    {file = "pyferris-0.5.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a8d9f06ef81c87c20c3eda66b821419620bc07dc543f73403d6f34bc21dc83d0"},
+    {file = "pyferris-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:250294e6955994181eaf1c6d72ed83d622f946eac6d34b4985df5b06bf6c19a7"},
+    {file = "pyferris-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:03d02dfcf2c96b9c5fb6c07dfe2c7474ca91aa1c10b10266b6e7c59a9103cf6d"},
+    {file = "pyferris-0.5.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f28b02b359d2fb0f62dbb18edb7dc0b5a50b1ef111970e189942d0b02e44266"},
+    {file = "pyferris-0.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16bc0a15b961d7dbe42eb4dff3cbca9f416bdd52ff677f20292fefae2fc3e31e"},
+    {file = "pyferris-0.5.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5577e6798bcc516422e0b8315d1d3b752e0b7385d67eadc1c2ceca3519ad2958"},
+    {file = "pyferris-0.5.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f98809b2198ae7b3f325ce22b0a08ee909efbb14e6d35ddf56aae33a1136c550"},
+    {file = "pyferris-0.5.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1dfbea666811f96bd0854f49b3b94720d98737ac263384f2f97227baf5c70413"},
+    {file = "pyferris-0.5.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c54df1454d2cf6e2ea0d64d6c15a5d79fa870990bdd82f597b00f8c3099c801"},
+    {file = "pyferris-0.5.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:13d1e0061224e98db01f3cfd25052e60620ce95eec82001d277f751911148d8a"},
+    {file = "pyferris-0.5.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb7a8ec1b2c815a6c6f1f3c316c5b057621badcf067147efeebca7ca72569508"},
+    {file = "pyferris-0.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6ef880062900c9905d03f82aa2ded1fd1e424f61778eb4407fd480be966edca3"},
+    {file = "pyferris-0.5.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:2055394ea66f82fc1afb1f3ac54e1ec0cb5ed446acba8a2ccf22e3a212e58aec"},
+    {file = "pyferris-0.5.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:696681f2b65d95c42ff6db7be689f17262cdf621d8d8380aa8e30077d5242a86"},
+    {file = "pyferris-0.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f6eb7ffd722a31087c6669b51ae7f89e9d3dda46567b3e4014982be1bd4a26c6"},
+    {file = "pyferris-0.5.2-cp313-cp313-win32.whl", hash = "sha256:41fee1ec419e1b96b51263a4ca90a46d74c05efe171e3866226297f54ecbff84"},
+    {file = "pyferris-0.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:2bac2fdb58fe1ceec1b17ae30e5369e3b091094b90db9ab4df7d15754e6e883c"},
+    {file = "pyferris-0.5.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ace2beb131a7e0bd5197792d6f521b4d365b2854aa080518894c05dffa812765"},
+    {file = "pyferris-0.5.2-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:06b3c1de1859ba60613c653082afacacebd4bb1761fba7cda59bc81a4850090c"},
+    {file = "pyferris-0.5.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86047c604652f4f920da44986c46621135df68060436e5a153c529563916cba8"},
+    {file = "pyferris-0.5.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:11ce95d90df1ad72e17b0cdcb34b217746e100c6e090f2fdfa0b2a9b466fe524"},
+    {file = "pyferris-0.5.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:996e9c6a17f81a7486e5a4eba7e1ba85db6c70e219d0e174ad070610475ad72c"},
+    {file = "pyferris-0.5.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:810da881f42da8cbaaaa9f191d19f4d83330d8c12029bdcb05165f1d276e50ef"},
+    {file = "pyferris-0.5.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:287b32d426c64cdcf7462b0c19d2a37a957725cdbb82278b9d0cb288bd944edc"},
+    {file = "pyferris-0.5.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b527c0b323fbb4172dbbfb6c6feab82ef54b09300bfb3184151ba477e9f38464"},
+    {file = "pyferris-0.5.2-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f8603f5d7fd6905d14d9cf2d378e29ef452a8a56cb2c524c01465d7f6f703cf8"},
+    {file = "pyferris-0.5.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b117d087b2367fcd50c4f68384e55d426ff42f86bcc771fe4891b0f0bc045f72"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a7002a2361eabc54f6604913cb518219f5f359fcc3a989474df4bcf4bfa83f7e"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62424c4dfb2ced87d635e46f20f12a008330e5e45a280b40d994db1f214dcde4"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:68a99bdd70369ff121f64db6f7a0ab43be23da222c26e3a6eeb01bf085453239"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c7fb38dede7cd1c664c091692513ec9e539940d88feacfe7a574ee121cd63be7"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:beabe62f950939342819ffd127a4e8223a394fa05180a3f1473dab7d70db0125"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:5bf88f2f94084ff40df791bfa8b83e7d62fc734014f772edb756267e6b14e2ac"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:ae4415b4852f8df58e2823e6fbf69c17c46a5d8f7444d73025de43e99c3b5d2b"},
+    {file = "pyferris-0.5.2-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ce076ce75a1f7a787106f6644411ac70b9c25e1f4516d071ad7f67991f3c0076"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24e0b3fce575564ef7231edc815a88fbdb5385f59475e77dc745d1e27967c63f"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f350ce3b54da5d9b531313486f1dc73e578b623d3c2e084af68c6e5dad1ff7e6"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84a49a2d50f17eca6d18a81c1204f8b5c954a59e2ad50e491d44f305a2431166"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02720ef104c095d402c47b7a989c4db7ccfb10b5b694f1c699c7f3dde013d4bb"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:95ac889f1a80a7972adecbc327033ebb2bfc44aed780a5ae3456fed0b85c7554"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc0d1cbddac9f7b3871b4d4850236a3b6a32ac5b8a17fa4ae002dfcd9a18f800"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:aa9f44cc38a83272f3665f7012b62973ee11c78a20a7293ed125ba2f4a113991"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:e9b1dcbcf395cd3f7aa6f4e252910f394db190953dadaa1229a991e7f50bac7d"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:69568a4395375f5def6dea3fb6ddcaae35043880ddf88eaf1828f003100ed861"},
+    {file = "pyferris-0.5.2-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:7fc428215b8c5e61e31b88022f2722fb540650d4818f1f303232fea981b107ea"},
+    {file = "pyferris-0.5.2.tar.gz", hash = "sha256:e51ec8efdb84e22e516169ec9a4f910d01b9a68f1e12432d0d75c06f4cbce466"},
 ]
 
 [[package]]
@@ -1975,24 +1992,24 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments
 
 [[package]]
 name = "pytest-codspeed"
-version = "3.2.0"
+version = "4.0.0"
 description = "Pytest plugin to create CodSpeed benchmarks"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest_codspeed-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5165774424c7ab8db7e7acdb539763a0e5657996effefdf0664d7fd95158d34"},
-    {file = "pytest_codspeed-3.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bd55f92d772592c04a55209950c50880413ae46876e66bd349ef157075ca26c"},
-    {file = "pytest_codspeed-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cf6f56067538f4892baa8d7ab5ef4e45bb59033be1ef18759a2c7fc55b32035"},
-    {file = "pytest_codspeed-3.2.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a687b05c3d145642061b45ea78e47e12f13ce510104d1a2cda00eee0e36f58"},
-    {file = "pytest_codspeed-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46a1afaaa1ac4c2ca5b0700d31ac46d80a27612961d031067d73c6ccbd8d3c2b"},
-    {file = "pytest_codspeed-3.2.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c48ce3af3dfa78413ed3d69d1924043aa1519048dbff46edccf8f35a25dab3c2"},
-    {file = "pytest_codspeed-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66692506d33453df48b36a84703448cb8b22953eea51f03fbb2eb758dc2bdc4f"},
-    {file = "pytest_codspeed-3.2.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:479774f80d0bdfafa16112700df4dbd31bf2a6757fac74795fd79c0a7b3c389b"},
-    {file = "pytest_codspeed-3.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:109f9f4dd1088019c3b3f887d003b7d65f98a7736ca1d457884f5aa293e8e81c"},
-    {file = "pytest_codspeed-3.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2f69a03b52c9bb041aec1b8ee54b7b6c37a6d0a948786effa4c71157765b6da"},
-    {file = "pytest_codspeed-3.2.0-py3-none-any.whl", hash = "sha256:54b5c2e986d6a28e7b0af11d610ea57bd5531cec8326abe486f1b55b09d91c39"},
-    {file = "pytest_codspeed-3.2.0.tar.gz", hash = "sha256:f9d1b1a3b2c69cdc0490a1e8b1ced44bffbd0e8e21d81a7160cfdd923f6e8155"},
+    {file = "pytest_codspeed-4.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2517731b20a6aa9fe61d04822b802e1637ee67fd865189485b384a9d5897117f"},
+    {file = "pytest_codspeed-4.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1e5076bb5119d4f8248822b5cd6b768f70a18c7e1a7fbcd96a99cd4a6430096e"},
+    {file = "pytest_codspeed-4.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06b324acdfe2076a0c97a9d31e8645f820822d6f0e766c73426767ff887a9381"},
+    {file = "pytest_codspeed-4.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ebdac1a4d6138e1ca4f5391e7e3cafad6e3aa6d5660d1b243871b691bc1396c"},
+    {file = "pytest_codspeed-4.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f3def79d4072867d038a33e7f35bc7fb1a2a75236a624b3a690c5540017cb38"},
+    {file = "pytest_codspeed-4.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01d29d4538c2d111c0034f71811bcce577304506d22af4dd65df87fadf3ab495"},
+    {file = "pytest_codspeed-4.0.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90894c93c9e23f12487b7fdf16c28da8f6275d565056772072beb41a72a54cf9"},
+    {file = "pytest_codspeed-4.0.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79e9c40852fa7fc76776db4f1d290eceaeee2d6c5d2dc95a66c7cc690d83889e"},
+    {file = "pytest_codspeed-4.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7330b6eadd6a729d4dba95d26496ee1c6f1649d552f515ef537b14a43908eb67"},
+    {file = "pytest_codspeed-4.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1271cd28e895132b20d12875554a544ee041f7acfb8112af8a5c3cb201f2fc8"},
+    {file = "pytest_codspeed-4.0.0-py3-none-any.whl", hash = "sha256:c5debd4b127dc1c507397a8304776f52cabbfa53aad6f51eae329a5489df1e06"},
+    {file = "pytest_codspeed-4.0.0.tar.gz", hash = "sha256:0e9af08ca93ad897b376771db92693a81aa8990eecc2a778740412e00a6f6eaf"},
 ]
 
 [package.dependencies]
@@ -2002,28 +2019,28 @@ rich = ">=13.8.1"
 
 [package.extras]
 compat = ["pytest-benchmark (>=5.0.0,<5.1.0)", "pytest-xdist (>=3.6.1,<3.7.0)"]
-lint = ["mypy (>=1.11.2,<1.12.0)", "ruff (>=0.6.5,<0.7.0)"]
+lint = ["mypy (>=1.11.2,<1.12.0)", "ruff (>=0.11.12,<0.12.0)"]
 test = ["pytest (>=7.0,<8.0)", "pytest-cov (>=4.0.0,<4.1.0)"]
 
 [[package]]
 name = "pytest-cov"
-version = "6.2.1"
+version = "7.0.0"
 description = "Pytest plugin for measuring coverage."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5"},
-    {file = "pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2"},
+    {file = "pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861"},
+    {file = "pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1"},
 ]
 
 [package.dependencies]
-coverage = {version = ">=7.5", extras = ["toml"]}
+coverage = {version = ">=7.10.6", extras = ["toml"]}
 pluggy = ">=1.2"
-pytest = ">=6.2.5"
+pytest = ">=7"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+testing = ["process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "python-dateutil"
@@ -2239,30 +2256,31 @@ test = ["pytest (>=7.4.2,<7.5.0)", "pytest-asyncio (>=0.21.1,<0.22.0)"]
 
 [[package]]
 name = "ruff"
-version = "0.8.6"
+version = "0.13.0"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.8.6-py3-none-linux_armv6l.whl", hash = "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3"},
-    {file = "ruff-0.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1"},
-    {file = "ruff-0.8.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807"},
-    {file = "ruff-0.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25"},
-    {file = "ruff-0.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d"},
-    {file = "ruff-0.8.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75"},
-    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315"},
-    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188"},
-    {file = "ruff-0.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf"},
-    {file = "ruff-0.8.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117"},
-    {file = "ruff-0.8.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe"},
-    {file = "ruff-0.8.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d"},
-    {file = "ruff-0.8.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a"},
-    {file = "ruff-0.8.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76"},
-    {file = "ruff-0.8.6-py3-none-win32.whl", hash = "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764"},
-    {file = "ruff-0.8.6-py3-none-win_amd64.whl", hash = "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905"},
-    {file = "ruff-0.8.6-py3-none-win_arm64.whl", hash = "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162"},
-    {file = "ruff-0.8.6.tar.gz", hash = "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5"},
+    {file = "ruff-0.13.0-py3-none-linux_armv6l.whl", hash = "sha256:137f3d65d58ee828ae136a12d1dc33d992773d8f7644bc6b82714570f31b2004"},
+    {file = "ruff-0.13.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:21ae48151b66e71fd111b7d79f9ad358814ed58c339631450c66a4be33cc28b9"},
+    {file = "ruff-0.13.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:64de45f4ca5441209e41742d527944635a05a6e7c05798904f39c85bafa819e3"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2b2c653ae9b9d46e0ef62fc6fbf5b979bda20a0b1d2b22f8f7eb0cde9f4963b8"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4cec632534332062bc9eb5884a267b689085a1afea9801bf94e3ba7498a2d207"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcd628101d9f7d122e120ac7c17e0a0f468b19bc925501dbe03c1cb7f5415b24"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:afe37db8e1466acb173bb2a39ca92df00570e0fd7c94c72d87b51b21bb63efea"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f96a8d90bb258d7d3358b372905fe7333aaacf6c39e2408b9f8ba181f4b6ef2"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:94b5e3d883e4f924c5298e3f2ee0f3085819c14f68d1e5b6715597681433f153"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03447f3d18479df3d24917a92d768a89f873a7181a064858ea90a804a7538991"},
+    {file = "ruff-0.13.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fbc6b1934eb1c0033da427c805e27d164bb713f8e273a024a7e86176d7f462cf"},
+    {file = "ruff-0.13.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a8ab6a3e03665d39d4a25ee199d207a488724f022db0e1fe4002968abdb8001b"},
+    {file = "ruff-0.13.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d2a5c62f8ccc6dd2fe259917482de7275cecc86141ee10432727c4816235bc41"},
+    {file = "ruff-0.13.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b7b85ca27aeeb1ab421bc787009831cffe6048faae08ad80867edab9f2760945"},
+    {file = "ruff-0.13.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:79ea0c44a3032af768cabfd9616e44c24303af49d633b43e3a5096e009ebe823"},
+    {file = "ruff-0.13.0-py3-none-win32.whl", hash = "sha256:4e473e8f0e6a04e4113f2e1de12a5039579892329ecc49958424e5568ef4f768"},
+    {file = "ruff-0.13.0-py3-none-win_amd64.whl", hash = "sha256:48e5c25c7a3713eea9ce755995767f4dcd1b0b9599b638b12946e892123d1efb"},
+    {file = "ruff-0.13.0-py3-none-win_arm64.whl", hash = "sha256:ab80525317b1e1d38614addec8ac954f1b3e662de9d59114ecbf771d00cf613e"},
+    {file = "ruff-0.13.0.tar.gz", hash = "sha256:5b4b1ee7eb35afae128ab94459b13b2baaed282b1fb0f472a73c82c996c8ae60"},
 ]
 
 [[package]]
@@ -2804,4 +2822,4 @@ docs = ["jinja2", "markdown", "weasyprint"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "46ec4aa695dd22ae4ccc365281cbf6a0dda270da4fd3248da02c242061504381"
+content-hash = "43c1e245eed4708553202a80ffce060172c6e23b62356abf62cf551a79d31ec4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "granian[asyncio,reload,rloop,uvloop] (>=2.2.6,<3.0.0)",
     "orjson (>=3.10.16,<4.0.0)",
     "pydantic[email] (>=2.11.7,<3.0.0)",
-    "pyferris (>=0.4.0,<0.5.0)",
+    "pyferris (>=0.5.0,<1.0.0)",
 ]
 
 [project.optional-dependencies]
@@ -54,11 +54,11 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"
-pytest-codspeed = "^3.2.0"
-pytest-cov = "^6.0.0"
-ruff = "^0.8.0"
-black = "^24.0.0"
-isort = "^5.13.0"
+pytest-codspeed = "^4.0.0"
+pytest-cov = "^7.0.0"
+ruff = "^0.13.0"
+black = "^25.1.0"
+isort = "^6.0.1"
 bandit = "^1.8.0"
 coverage = "^7.6.0"
 

--- a/tests/app/di.py
+++ b/tests/app/di.py
@@ -11,14 +11,14 @@ logger = logging.getLogger(__name__)
 
 class TestSingletonProvider(HTTPEndpoint):
     @inject
-    async def get(self, db: MockDatabase = Provide[container.db]):
+    def get(self, db: MockDatabase = Provide[container.db]):
         assert isinstance(db, MockDatabase)
         return PlainTextResponse('success')
 
 
 class TestFactoryProvider(HTTPEndpoint):
     @inject
-    async def get(
+    def get(
         self, user_repository: MockUserRepository = Provide[container.user_repository]
     ):
         assert isinstance(user_repository, MockUserRepository)
@@ -27,7 +27,7 @@ class TestFactoryProvider(HTTPEndpoint):
 
 class TestAsyncFactoryProvider(HTTPEndpoint):
     @inject
-    async def get(
+    def get(
         self, user_service: MockUserService = Provide[container.user_service]
     ):
         assert isinstance(user_service, MockUserService)

--- a/tests/app/function_deps.py
+++ b/tests/app/function_deps.py
@@ -32,7 +32,7 @@ def get_constant(_) -> str:
 class TestFunctionDependencyEndpoint(HTTPEndpoint):
     """Test endpoint for function dependency injection."""
 
-    async def get(
+    def get(
         self,
         user_id: Annotated[str, get_user_id],
         permissions: Annotated[list[str], get_user_permissions],

--- a/velithon/_utils.py
+++ b/velithon/_utils.py
@@ -35,7 +35,7 @@ def set_thread_pool() -> None:
             # For CPU bound: cpu_count or cpu_count + 1
             max_workers = min(32, cpu_count * 2)
 
-            _thread_pool = pyferris.Executor(
+            _thread_pool = pyferris.AsyncExecutor(
                 max_workers=max_workers,
             )
 


### PR DESCRIPTION
- Updated `pyferris` dependency version from `>=0.4.0,<0.5.0` to `>=0.5.0,<1.0.0` in `pyproject.toml`.
- Upgraded development dependencies in `pyproject.toml`:
  - `pytest-codspeed` from `^3.2.0` to `^4.0.0`
  - `pytest-cov` from `^6.0.0` to `^7.0.0`
  - `ruff` from `^0.8.0` to `^0.13.0`
  - `black` from `^24.0.0` to `^25.1.0`
  - `isort` from `^5.13.0` to `^6.0.1`
- Refactored `get` methods in `tests/app/di.py` and `tests/app/function_deps.py` to remove `async` keyword, aligning with the updated usage of dependency injection.
- Changed the thread pool executor in `velithon/_utils.py` from `pyferris.Executor` to `pyferris.AsyncExecutor` for improved async handling.