### PR TITLE
feat(graphql): Add GraphQL support to Velithon framework

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -998,6 +998,18 @@ rloop = ["rloop (>=0.1,<1.0) ; sys_platform != \"win32\""]
 uvloop = ["uvloop (>=0.18.0) ; platform_python_implementation == \"CPython\" and sys_platform != \"win32\""]
 
 [[package]]
+name = "graphql-core"
+version = "3.2.6"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+optional = false
+python-versions = "<4,>=3.6"
+groups = ["main"]
+files = [
+    {file = "graphql_core-3.2.6-py3-none-any.whl", hash = "sha256:78b016718c161a6fb20a7d97bbf107f331cd1afe53e45566c59f776ed7f0b45f"},
+    {file = "graphql_core-3.2.6.tar.gz", hash = "sha256:c08eec22f9e40f0bd61d805907e3b3b1b9a320bc606e23dc145eebca07c8fbab"},
+]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -1533,6 +1545,8 @@ markers = "extra == \"docs\""
 files = [
     {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
     {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0"},
+    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b"},
     {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50"},
     {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae"},
     {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9"},
@@ -1542,6 +1556,8 @@ files = [
     {file = "pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f"},
     {file = "pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722"},
     {file = "pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d"},
+    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494"},
     {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58"},
     {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f"},
     {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e"},
@@ -1551,6 +1567,8 @@ files = [
     {file = "pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd"},
     {file = "pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4"},
     {file = "pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d"},
+    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6"},
     {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7"},
     {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024"},
     {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809"},
@@ -1563,6 +1581,8 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f"},
     {file = "pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c"},
     {file = "pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e"},
+    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1"},
     {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805"},
     {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8"},
     {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2"},
@@ -1572,6 +1592,8 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580"},
     {file = "pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e"},
     {file = "pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced"},
+    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c"},
     {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8"},
     {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59"},
     {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe"},
@@ -1581,6 +1603,8 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e"},
     {file = "pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12"},
     {file = "pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632"},
+    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673"},
     {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027"},
     {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77"},
     {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874"},
@@ -1590,6 +1614,8 @@ files = [
     {file = "pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6"},
     {file = "pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae"},
     {file = "pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6"},
+    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36"},
     {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b"},
     {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477"},
     {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50"},
@@ -1599,6 +1625,8 @@ files = [
     {file = "pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa"},
     {file = "pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f"},
     {file = "pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4"},
+    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc"},
     {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06"},
     {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a"},
     {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978"},
@@ -1608,11 +1636,15 @@ files = [
     {file = "pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c"},
+    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"},
+    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
@@ -2822,4 +2854,4 @@ docs = ["jinja2", "markdown", "weasyprint"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "43c1e245eed4708553202a80ffce060172c6e23b62356abf62cf551a79d31ec4"
+content-hash = "9cdd1d4ecb6e50feece09b0c5005134649386edd84679441d5aec5eee423d3c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "orjson (>=3.10.16,<4.0.0)",
     "pydantic[email] (>=2.11.7,<3.0.0)",
     "pyferris (>=0.5.0,<1.0.0)",
+    "graphql-core (>=3.2.6,<4.0.0)",
 ]
 
 [project.optional-dependencies]

--- a/velithon/__init__.py
+++ b/velithon/__init__.py
@@ -59,6 +59,23 @@ from .status import (
     HTTP_500_INTERNAL_SERVER_ERROR,
 )
 
+# GraphQL support
+from .graphql import (
+    GraphQLEndpoint,
+    GraphQLMiddleware,
+    GraphQLPlayground,
+    GraphQLRoute,
+    GraphQLSchema,
+    Field,
+    Mutation,
+    ObjectType,
+    Query,
+    Subscription,
+    graphql_field,
+    graphql_route,
+    graphql_type,
+)
+
 # Context management (Flask-style)
 from .ctx import (
     AppContext,
@@ -87,19 +104,28 @@ __all__ = [
     # Context management
     'AppContext',
     'BadRequestException',
+    'Field',
     'FileResponse',
     'ForbiddenException',
     'Gateway',
     'GatewayRoute',
+    'GraphQLEndpoint',
+    'GraphQLMiddleware',
+    'GraphQLPlayground',
+    'GraphQLRoute',
+    'GraphQLSchema',
     'HTMLResponse',
     'HTTPException',
     'InternalServerException',
     'JSONResponse',
     'Middleware',
+    'Mutation',
     'NotFoundException',
+    'ObjectType',
     # Performance configuration
     'PlainTextResponse',
     'ProxyResponse',
+    'Query',
     'RedirectResponse',
     'Request',
     'RequestContext',
@@ -109,6 +135,7 @@ __all__ = [
     'Router',
     'SSEResponse',
     'StreamingResponse',
+    'Subscription',
     'UnauthorizedException',
     'ValidationException',
     'Velithon',
@@ -123,6 +150,9 @@ __all__ = [
     'get_current_app',
     'get_current_request',
     'get_or_create_request',
+    'graphql_field',
+    'graphql_route',
+    'graphql_type',
     'has_app_context',
     'has_request_context',
     'request',

--- a/velithon/graphql/__init__.py
+++ b/velithon/graphql/__init__.py
@@ -1,0 +1,41 @@
+"""GraphQL support for Velithon framework.
+
+This module provides comprehensive GraphQL support for Velithon,
+including schema definition, query execution, and GraphQL Playground integration.
+Following Velithon's Rust-first approach for performance optimization.
+"""
+
+from .endpoint import GraphQLEndpoint
+from .middleware import GraphQLMiddleware, GraphQLAuthMiddleware, \
+    GraphQLLoggingMiddleware
+from .playground import GraphQLPlayground, get_playground_html
+from .route import GraphQLRoute, graphql_route
+from .schema import (
+    Field,
+    GraphQLSchema,
+    Mutation,
+    ObjectType,
+    Query,
+    Subscription,
+    graphql_field,
+    graphql_type,
+)
+
+__all__ = [
+    "Field",
+    "GraphQLAuthMiddleware",
+    "GraphQLEndpoint",
+    "GraphQLLoggingMiddleware",
+    "GraphQLMiddleware",
+    "GraphQLPlayground",
+    "GraphQLRoute",
+    "GraphQLSchema",
+    "Mutation",
+    "ObjectType",
+    "Query",
+    "Subscription",
+    "get_playground_html",
+    "graphql_field",
+    "graphql_route",
+    "graphql_type",
+]

--- a/velithon/graphql/endpoint.py
+++ b/velithon/graphql/endpoint.py
@@ -1,0 +1,268 @@
+"""GraphQL endpoint implementation for Velithon framework.
+
+This module provides the core GraphQL endpoint that handles GraphQL queries,
+mutations, and subscriptions following Velithon's performance-first approach.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from graphql import GraphQLError, execute, parse, validate
+
+from velithon.endpoint import HTTPEndpoint
+from velithon.exceptions import BadRequestException, InternalServerException
+from velithon.requests import Request
+from velithon.responses import HTMLResponse, JSONResponse, Response
+
+from .schema import GraphQLSchema
+
+logger = logging.getLogger(__name__)
+
+
+class GraphQLEndpoint(HTTPEndpoint):
+    """HTTP endpoint for handling GraphQL requests.
+
+    This endpoint supports both GET and POST requests for GraphQL operations:
+    - GET requests for queries with query parameters
+    - POST requests for queries, mutations, and subscriptions with JSON body
+    """
+
+    def __init__(
+        self,
+        schema: GraphQLSchema,
+        context_value: Any = None,
+        root_value: Any = None,
+        debug: bool = False,
+        introspection: bool = True,
+        playground: bool = True,
+    ):
+        """Initialize GraphQL endpoint.
+
+        Args:
+            schema: GraphQL schema instance
+            context_value: Context value passed to resolvers
+            root_value: Root value for resolvers
+            debug: Enable debug mode for detailed error messages
+            introspection: Enable GraphQL introspection
+            playground: Enable GraphQL Playground
+
+        """
+        self.schema = schema
+        self.context_value = context_value
+        self.root_value = root_value
+        self.debug = debug
+        self.introspection = introspection
+        self.playground = playground
+
+    async def get(self, request: Request) -> Response:
+        """Handle GET requests for GraphQL queries.
+
+        Args:
+            request: The HTTP request object
+
+        Returns:
+            Response: GraphQL query result or GraphQL Playground HTML
+
+        """
+        # Check if this is a request for GraphQL Playground
+        accept_header = request.headers.get("accept", "")
+        if "text/html" in accept_header and self.playground:
+            return await self._serve_playground(request)
+
+        # Handle GraphQL query via GET
+        query = request.query_params.get("query")
+        if not query:
+            raise BadRequestException("Missing 'query' parameter")
+
+        variables_param = request.query_params.get("variables")
+        variables = None
+        if variables_param:
+            try:
+                variables = json.loads(variables_param)
+            except json.JSONDecodeError as e:
+                raise BadRequestException(f"Invalid variables JSON: {e}") from e
+
+        operation_name = request.query_params.get("operationName")
+
+        return await self._execute_graphql(
+            query=query,
+            variables=variables,
+            operation_name=operation_name,
+            context_value=self.context_value,
+            request=request,
+        )
+
+    async def post(self, request: Request) -> Response:
+        """Handle POST requests for GraphQL operations.
+
+        Args:
+            request: The HTTP request object
+
+        Returns:
+            Response: GraphQL operation result
+
+        """
+        content_type = request.headers.get("content-type", "")
+
+        if not content_type.startswith("application/json"):
+            raise BadRequestException("Content-Type must be application/json")
+
+        try:
+            body = await request.json()
+        except Exception as e:
+            raise BadRequestException(f"Invalid JSON body: {e}") from e
+
+        if not isinstance(body, dict):
+            raise BadRequestException("Request body must be a JSON object")
+
+        query = body.get("query")
+        if not query:
+            raise BadRequestException("Missing 'query' field in request body")
+
+        variables = body.get("variables")
+        operation_name = body.get("operationName")
+
+        return await self._execute_graphql(
+            query=query,
+            variables=variables,
+            operation_name=operation_name,
+            context_value=self.context_value,
+            request=request,
+        )
+
+    async def _execute_graphql(
+        self,
+        query: str,
+        variables: dict[str, Any] | None = None,
+        operation_name: str | None = None,
+        context_value: Any = None,
+        request: Request | None = None,
+    ) -> Response:
+        """Execute a GraphQL operation.
+
+        Args:
+            query: GraphQL query string
+            variables: Query variables
+            operation_name: Name of the operation to execute
+            context_value: Context value for resolvers
+            request: HTTP request object
+
+        Returns:
+            Response: GraphQL execution result
+
+        """
+        try:
+            # Parse the query
+            try:
+                document = parse(query)
+            except GraphQLError as e:
+                return JSONResponse(
+                    {"errors": [{"message": str(e)}]},
+                    status_code=400,
+                )
+
+            # Validate the query against the schema
+            schema = self.schema.build()
+            validation_errors = validate(schema, document)
+            if validation_errors:
+                return JSONResponse(
+                    {
+                        "errors": [
+                            {"message": str(error)} for error in validation_errors
+                        ]
+                    },
+                    status_code=400,
+                )
+
+            # Create context with request if available
+            execution_context = context_value or {}
+            if request:
+                execution_context = {
+                    **(
+                        execution_context
+                        if isinstance(execution_context, dict)
+                        else {}
+                    ),
+                    "request": request,
+                }
+
+            # Execute the query
+            result = execute(
+                schema=schema,
+                document=document,
+                root_value=self.root_value,
+                context_value=execution_context,
+                variable_values=variables,
+                operation_name=operation_name,
+            )
+
+            # Format the response
+            response_data = {"data": result.data}
+
+            if result.errors:
+                response_data["errors"] = [
+                    {
+                        "message": str(error),
+                        "locations": (
+                            [
+                                {"line": loc.line, "column": loc.column}
+                                for loc in error.locations
+                            ]
+                            if error.locations
+                            else None
+                        ),
+                        "path": error.path,
+                    }
+                    for error in result.errors
+                ]
+
+            # Include extensions if present
+            if hasattr(result, "extensions") and result.extensions:
+                response_data["extensions"] = result.extensions
+
+            return JSONResponse(response_data)
+
+        except Exception as e:
+            logger.exception("GraphQL execution error: %s", str(e))
+
+            if self.debug:
+                return JSONResponse(
+                    {
+                        "errors": [
+                            {
+                                "message": str(e),
+                                "extensions": {
+                                    "code": "INTERNAL_ERROR",
+                                    "exception": {
+                                        "stacktrace": [str(e)],
+                                    },
+                                },
+                            }
+                        ]
+                    },
+                    status_code=500,
+                )
+            else:
+                raise InternalServerException("Internal server error") from e
+
+    async def _serve_playground(self, request: Request) -> Response:
+        """Serve GraphQL Playground HTML.
+
+        Args:
+            request: HTTP request object
+
+        Returns:
+            Response: HTML response with GraphQL Playground
+
+        """
+        from .playground import get_playground_html
+
+        playground_html = get_playground_html(
+            endpoint_url=str(request.url.path),
+            subscription_endpoint=None,  # TODO: Add WebSocket support
+        )
+
+        return HTMLResponse(playground_html)

--- a/velithon/graphql/middleware.py
+++ b/velithon/graphql/middleware.py
@@ -1,0 +1,189 @@
+"""GraphQL middleware for Velithon framework.
+
+This module provides middleware components for GraphQL request processing,
+including authentication, authorization, and query complexity analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from velithon.middleware.base import BaseHTTPMiddleware
+from velithon.requests import Request
+
+logger = logging.getLogger(__name__)
+
+
+class GraphQLMiddleware(BaseHTTPMiddleware):
+    """Middleware for GraphQL request processing.
+
+    This middleware provides common GraphQL functionality such as:
+    - Request/response logging
+    - Query complexity analysis
+    - Authentication and authorization
+    - Request transformation
+    """
+
+    def __init__(
+        self,
+        app,
+        *,
+        max_query_complexity: int | None = None,
+        auth_required: bool = False,
+        auth_checker: Callable[[Request], bool] | None = None,
+        context_processor: Callable[[Request], dict[str, Any]] | None = None,
+        log_queries: bool = False,
+    ):
+        """Initialize GraphQL middleware.
+
+        Args:
+            app: RSGI application
+            max_query_complexity: Maximum allowed query complexity
+            auth_required: Whether authentication is required
+            auth_checker: Function to check authentication
+            context_processor: Function to process request context
+            log_queries: Whether to log GraphQL queries
+
+        """
+        super().__init__(app)
+        self.max_query_complexity = max_query_complexity
+        self.auth_required = auth_required
+        self.auth_checker = auth_checker
+        self.context_processor = context_processor
+        self.log_queries = log_queries
+
+    async def process_http_request(self, scope, protocol):
+        """Process HTTP request for GraphQL endpoints."""
+        # Check if this is a GraphQL request
+        if not self._is_graphql_request(scope):
+            return await self.app(scope, protocol)
+
+        request = Request(scope, protocol)
+
+        # Authentication check
+        if self.auth_required:
+            if not await self._check_authentication(request):
+                from velithon.exceptions import UnauthorizedException
+
+                raise UnauthorizedException("Authentication required")
+
+        # Process context
+        if self.context_processor:
+            context = await self._process_context(request)
+            # Store context in scope for GraphQL execution
+            scope._graphql_context = context
+
+        # Query logging
+        if self.log_queries:
+            await self._log_query(request)
+
+        # Continue to the next middleware/application
+        return await self.app(scope, protocol)
+
+    def _is_graphql_request(self, scope) -> bool:
+        """Check if the request is for a GraphQL endpoint."""
+        path = scope.path
+        content_type = dict(scope.headers).get(b"content-type", b"")
+
+        # Check for common GraphQL paths or content types
+        return (
+            "/graphql" in path
+            or "/graphiql" in path
+            or b"application/json" in content_type
+        )
+
+    async def _check_authentication(self, request: Request) -> bool:
+        """Check if the request is authenticated."""
+        if self.auth_checker:
+            return await self._call_async(self.auth_checker, request)
+
+        # Default authentication check (look for Authorization header)
+        auth_header = request.headers.get("authorization")
+        return bool(auth_header)
+
+    async def _process_context(self, request: Request) -> dict[str, Any]:
+        """Process request context."""
+        if self.context_processor:
+            context = await self._call_async(self.context_processor, request)
+            return context if isinstance(context, dict) else {}
+        return {}
+
+    async def _log_query(self, request: Request) -> None:
+        """Log GraphQL query for debugging."""
+        try:
+            if request.method == "POST":
+                body = await request.json()
+                query = body.get("query", "")
+                operation_name = body.get("operationName", "")
+                logger.info(
+                    "GraphQL Query - Operation: %s, Query: %s",
+                    operation_name or "Anonymous",
+                    query[:200] + ("..." if len(query) > 200 else ""),
+                )
+            elif request.method == "GET":
+                query = request.query_params.get("query", "")
+                operation_name = request.query_params.get("operationName", "")
+                logger.info(
+                    "GraphQL Query - Operation: %s, Query: %s",
+                    operation_name or "Anonymous",
+                    query[:200] + ("..." if len(query) > 200 else ""),
+                )
+        except Exception as e:
+            logger.warning("Failed to log GraphQL query: %s", str(e))
+
+    async def _call_async(self, func: Callable, *args, **kwargs) -> Any:
+        """Call a function that may be sync or async."""
+        import inspect
+
+        if inspect.iscoroutinefunction(func):
+            return await func(*args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+
+
+class GraphQLAuthMiddleware(GraphQLMiddleware):
+    """Specialized middleware for GraphQL authentication."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        auth_checker: Callable[[Request], bool],
+        unauthorized_message: str = "Authentication required for GraphQL",
+    ):
+        """Initialize GraphQL authentication middleware.
+
+        Args:
+            app: RSGI application
+            auth_checker: Function to check authentication
+            unauthorized_message: Message for unauthorized requests
+
+        """
+        super().__init__(app, auth_required=True, auth_checker=auth_checker)
+        self.unauthorized_message = unauthorized_message
+
+
+class GraphQLLoggingMiddleware(GraphQLMiddleware):
+    """Specialized middleware for GraphQL query logging."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        log_queries: bool = True,
+        log_responses: bool = False,
+        max_query_length: int = 1000,
+    ):
+        """Initialize GraphQL logging middleware.
+
+        Args:
+            app: RSGI application
+            log_queries: Whether to log queries
+            log_responses: Whether to log responses
+            max_query_length: Maximum query length to log
+
+        """
+        super().__init__(app, log_queries=log_queries)
+        self.log_responses = log_responses
+        self.max_query_length = max_query_length

--- a/velithon/graphql/playground.py
+++ b/velithon/graphql/playground.py
@@ -1,0 +1,117 @@
+"""GraphQL Playground HTML generator for Velithon.
+
+This module provides functionality to serve GraphQL Playground,
+an interactive GraphQL IDE for development and testing.
+"""
+
+from __future__ import annotations
+
+
+class GraphQLPlayground:
+    """GraphQL Playground integration for Velithon."""
+
+    @staticmethod
+    def create_html(
+        endpoint_url: str = "/graphql",
+        subscription_endpoint: str | None = None,
+        title: str = "GraphQL Playground",
+    ) -> str:
+        """Create GraphQL Playground HTML.
+
+        Args:
+            endpoint_url: The GraphQL endpoint URL
+            subscription_endpoint: WebSocket endpoint for subscriptions
+            title: Page title
+
+        Returns:
+            str: HTML content for GraphQL Playground
+
+        """
+        return get_playground_html(endpoint_url, subscription_endpoint, title)
+
+
+def get_playground_html(
+    endpoint_url: str = "/graphql",
+    subscription_endpoint: str | None = None,
+    title: str = "GraphQL Playground",
+) -> str:
+    """Generate HTML for GraphQL Playground.
+
+    Args:
+        endpoint_url: The GraphQL endpoint URL
+        subscription_endpoint: WebSocket endpoint for subscriptions
+        title: Page title
+
+    Returns:
+        str: HTML content for GraphQL Playground
+
+    """
+    subscription_config = ""
+    if subscription_endpoint:
+        subscription_config = f"""
+        subscriptionEndpoint: '{subscription_endpoint}',
+        """
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+  <meta charset=utf-8/>
+  <meta name="viewport" content="user-scalable=no, initial-scale=1.0, \
+minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
+  <title>{title}</title>
+  <link rel="stylesheet" \
+href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+  <link rel="shortcut icon" \
+href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+  <script \
+src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js">\
+</script>
+</head>
+<body>
+  <div id="root">
+    <style>
+      body {{
+        background-color: rgb(23, 42, 58);
+        font-family: Open Sans, sans-serif;
+        height: 90vh;
+      }}
+      #root {{
+        height: 100%;
+        width: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }}
+      .loading {{
+        font-size: 32px;
+        font-weight: 200;
+        color: rgba(255, 255, 255, .6);
+        margin-left: 20px;
+      }}
+      img {{
+        width: 78px;
+        height: 78px;
+      }}
+      .title {{
+        font-weight: 400;
+      }}
+    </style>
+    <img src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png" alt="">
+    <div class="loading"> Loading
+      <span class="title">GraphQL Playground</span>
+    </div>
+  </div>
+  <script>window.addEventListener('load', function (event) {{
+      GraphQLPlayground.init(document.getElementById('root'), {{
+        endpoint: '{endpoint_url}',{subscription_config}
+        settings: {{
+          'general.betaUpdates': false,
+          'editor.theme': 'dark',
+          'editor.reuseHeaders': true,
+          'tracing.hideTracingResponse': true,
+          'editor.fontSize': 14,
+        }}
+      }})
+    }})</script>
+</body>
+</html>"""

--- a/velithon/graphql/route.py
+++ b/velithon/graphql/route.py
@@ -1,0 +1,189 @@
+"""GraphQL route implementation for Velithon framework.
+
+This module provides GraphQL route classes and decorators that integrate
+with Velithon's routing system.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from velithon.routing import BaseRoute
+
+from .endpoint import GraphQLEndpoint
+from .schema import GraphQLSchema
+
+
+class GraphQLRoute(BaseRoute):
+    """GraphQL route that handles GraphQL requests within Velithon's routing system."""
+
+    def __init__(
+        self,
+        path: str,
+        schema: GraphQLSchema,
+        context_value: Any = None,
+        root_value: Any = None,
+        debug: bool = False,
+        introspection: bool = True,
+        playground: bool = True,
+        name: str | None = None,
+    ):
+        """Initialize GraphQL route.
+
+        Args:
+            path: URL path for the GraphQL endpoint
+            schema: GraphQL schema instance
+            context_value: Context value passed to resolvers
+            root_value: Root value for resolvers
+            debug: Enable debug mode for detailed error messages
+            introspection: Enable GraphQL introspection
+            playground: Enable GraphQL Playground
+            name: Route name
+
+        """
+        self.path = path
+        self.schema = schema
+        self.context_value = context_value
+        self.root_value = root_value
+        self.debug = debug
+        self.introspection = introspection
+        self.playground = playground
+        self.name = name or "graphql"
+
+        # Create the GraphQL endpoint
+        self.endpoint = GraphQLEndpoint(
+            schema=schema,
+            context_value=context_value,
+            root_value=root_value,
+            debug=debug,
+            introspection=introspection,
+            playground=playground,
+        )
+
+    def matches(self, scope):
+        """Check if the route matches the given scope."""
+        from velithon._velithon import Match, compile_path
+
+        # Compile the path pattern
+        regex, _, _ = compile_path(self.path)
+
+        # Check if the path matches
+        path = scope.path
+        match = regex.match(path)
+
+        if match:
+            path_params = match.groupdict()
+            scope.path_params = path_params
+            return Match.FULL, scope
+        else:
+            return Match.NONE, scope
+
+    async def handle(self, scope, protocol):
+        """Handle the GraphQL request."""
+        return await self.endpoint(scope, protocol)
+
+    async def openapi(self):
+        """Generate OpenAPI documentation for GraphQL endpoint."""
+        # GraphQL endpoints typically don't use OpenAPI, but we can provide basic info
+        path_schema = {
+            "get": {
+                "summary": "GraphQL Playground",
+                "description": "Interactive GraphQL IDE for development and testing",
+                "responses": {
+                    "200": {
+                        "description": "GraphQL Playground HTML",
+                        "content": {"text/html": {"schema": {"type": "string"}}},
+                    }
+                },
+            },
+            "post": {
+                "summary": "GraphQL Query",
+                "description": "Execute GraphQL queries, mutations, and subscriptions",
+                "requestBody": {
+                    "required": True,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "description": "GraphQL query string",
+                                    },
+                                    "variables": {
+                                        "type": "object",
+                                        "description": "Query variables",
+                                    },
+                                    "operationName": {
+                                        "type": "string",
+                                        "description": "Operation name",
+                                    },
+                                },
+                                "required": ["query"],
+                            }
+                        }
+                    },
+                },
+                "responses": {
+                    "200": {
+                        "description": "GraphQL response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {"description": "Query result"},
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {"type": "object"},
+                                            "description": "Query errors",
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+            },
+        }
+
+        parameters = {}
+        return path_schema, parameters
+
+
+def graphql_route(
+    path: str,
+    schema: GraphQLSchema,
+    context_value: Any = None,
+    root_value: Any = None,
+    debug: bool = False,
+    introspection: bool = True,
+    playground: bool = True,
+    name: str | None = None,
+) -> GraphQLRoute:
+    """Create a GraphQL route.
+
+    Args:
+        path: URL path for the GraphQL endpoint
+        schema: GraphQL schema instance
+        context_value: Context value passed to resolvers
+        root_value: Root value for resolvers
+        debug: Enable debug mode for detailed error messages
+        introspection: Enable GraphQL introspection
+        playground: Enable GraphQL Playground
+        name: Route name
+
+    Returns:
+        GraphQLRoute: Configured GraphQL route
+
+    """
+    return GraphQLRoute(
+        path=path,
+        schema=schema,
+        context_value=context_value,
+        root_value=root_value,
+        debug=debug,
+        introspection=introspection,
+        playground=playground,
+        name=name,
+    )

--- a/velithon/graphql/schema.py
+++ b/velithon/graphql/schema.py
@@ -1,0 +1,313 @@
+"""GraphQL schema definition and type system for Velithon.
+
+This module provides classes and decorators for defining GraphQL schemas,
+types, fields, and resolvers following Velithon's performance-first approach.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, ClassVar, Union, get_args, get_origin
+
+from graphql import (
+    GraphQLArgument,
+    GraphQLBoolean,
+    GraphQLField,
+    GraphQLFloat,
+    GraphQLInt,
+    GraphQLList,
+    GraphQLObjectType,
+    GraphQLString,
+    GraphQLType,
+    print_schema,
+    validate_schema,
+)
+from graphql import (
+    GraphQLSchema as CoreGraphQLSchema,
+)
+
+
+class GraphQLTypeRegistry:
+    """Registry for GraphQL types and resolvers."""
+
+    def __init__(self):
+        """Initialize the type registry."""
+        self.types: dict[str, GraphQLType] = {}
+        self.resolvers: dict[str, dict[str, Callable]] = {}
+        self.fields: dict[str, dict[str, Field]] = {}
+
+    def register_type(self, name: str, graphql_type: GraphQLType) -> None:
+        """Register a GraphQL type."""
+        self.types[name] = graphql_type
+
+    def register_resolver(
+        self, type_name: str, field_name: str, resolver: Callable
+    ) -> None:
+        """Register a field resolver."""
+        if type_name not in self.resolvers:
+            self.resolvers[type_name] = {}
+        self.resolvers[type_name][field_name] = resolver
+
+    def register_field(self, type_name: str, field_name: str, field: Field) -> None:
+        """Register a field definition."""
+        if type_name not in self.fields:
+            self.fields[type_name] = {}
+        self.fields[type_name][field_name] = field
+
+
+# Global type registry
+_type_registry = GraphQLTypeRegistry()
+
+
+class Field:
+    """Represents a GraphQL field definition."""
+
+    def __init__(
+        self,
+        type_: str | type | GraphQLType,
+        description: str | None = None,
+        resolver: Callable | None = None,
+        deprecation_reason: str | None = None,
+        args: dict[str, Any] | None = None,
+    ):
+        """Initialize GraphQL field.
+
+        Args:
+            type_: The field type
+            description: Field description
+            resolver: Field resolver function
+            deprecation_reason: Deprecation reason if field is deprecated
+            args: Field arguments
+
+        """
+        self.type_ = type_
+        self.description = description
+        self.resolver = resolver
+        self.deprecation_reason = deprecation_reason
+        self.args = args or {}
+
+    def to_graphql_field(self) -> GraphQLField:
+        """Convert to GraphQL field."""
+        # Convert args to GraphQL arguments
+        graphql_args = {}
+        if self.args:
+            for arg_name, arg_info in self.args.items():
+                if isinstance(arg_info, dict):
+                    arg_type = arg_info.get('type', str)
+                    arg_description = arg_info.get('description', None)
+                    graphql_args[arg_name] = GraphQLArgument(
+                        type_=self._convert_type(arg_type), description=arg_description
+                    )
+                else:
+                    # Assume it's just a type
+                    graphql_args[arg_name] = GraphQLArgument(
+                        type_=self._convert_type(arg_info)
+                    )
+
+        return GraphQLField(
+            type_=self._convert_type(self.type_),
+            description=self.description,
+            resolve=self.resolver,
+            deprecation_reason=self.deprecation_reason,
+            args=graphql_args,
+        )
+
+    def _convert_type(self, type_: Any) -> GraphQLType:
+        """Convert Python type to GraphQL type."""
+        if isinstance(type_, GraphQLType):
+            return type_
+
+        # Handle basic types
+        if type_ is str:
+            return GraphQLString
+        elif type_ is int:
+            return GraphQLInt
+        elif type_ is float:
+            return GraphQLFloat
+        elif type_ is bool:
+            return GraphQLBoolean
+
+        # Handle Optional types
+        origin = get_origin(type_)
+        if origin is Union:
+            args = get_args(type_)
+            if len(args) == 2 and type(None) in args:
+                # This is Optional[T]
+                non_none_type = next(arg for arg in args if arg is not type(None))
+                return self._convert_type(non_none_type)
+
+        # Handle List types
+        if origin is list:
+            args = get_args(type_)
+            if args:
+                item_type = args[0]
+                # Check if it's a registered ObjectType
+                if (
+                    hasattr(item_type, '__name__')
+                    and item_type.__name__ in _type_registry.types
+                ):
+                    return GraphQLList(_type_registry.types[item_type.__name__])
+                return GraphQLList(self._convert_type(item_type))
+            return GraphQLList(GraphQLString)
+
+        # Handle direct list type
+        if type_ is list:
+            return GraphQLList(GraphQLString)
+
+        # Handle registered types (both class and string references)
+        if isinstance(type_, str) and type_ in _type_registry.types:
+            return _type_registry.types[type_]
+        elif hasattr(type_, '__name__') and type_.__name__ in _type_registry.types:
+            return _type_registry.types[type_.__name__]
+
+        # Default to String for unknown types
+        return GraphQLString
+
+
+def graphql_field(
+    type_: str | type | GraphQLType,
+    description: str | None = None,
+    deprecation_reason: str | None = None,
+    args: dict[str, Any] | None = None,
+) -> Callable:
+    """Define a GraphQL field."""
+
+    def decorator(func: Callable) -> Callable:
+        field = Field(
+            type_=type_,
+            description=description,
+            resolver=func,
+            deprecation_reason=deprecation_reason,
+            args=args,
+        )
+
+        # Store field information on the function
+        func._graphql_field = field
+        return func
+
+    return decorator
+
+
+class ObjectTypeMeta(type):
+    """Metaclass for GraphQL object types."""
+
+    def __new__(cls, name: str, bases: tuple, attrs: dict):
+        """Create new object type class."""
+        # Extract GraphQL fields from class attributes and methods
+        fields = {}
+
+        for attr_name, attr_value in attrs.items():
+            if hasattr(attr_value, '_graphql_field'):
+                fields[attr_name] = attr_value._graphql_field
+            elif isinstance(attr_value, Field):
+                fields[attr_name] = attr_value
+
+        # Store fields on the class
+        attrs['_graphql_fields'] = fields
+
+        # Create the class
+        new_class = super().__new__(cls, name, bases, attrs)
+
+        # Register the type
+        if name != 'ObjectType':  # Skip base class
+            _type_registry.register_field(name, name, fields)
+
+        return new_class
+
+
+class ObjectType(metaclass=ObjectTypeMeta):
+    """Base class for GraphQL object types."""
+
+    _graphql_fields: ClassVar[dict[str, Field]] = {}
+
+    @classmethod
+    def to_graphql_type(cls) -> GraphQLObjectType:
+        """Convert to GraphQL object type."""
+        fields = {}
+
+        for field_name, field in cls._graphql_fields.items():
+            fields[field_name] = field.to_graphql_field()
+
+        return GraphQLObjectType(
+            name=cls.__name__,
+            fields=fields,
+            description=cls.__doc__,
+        )
+
+
+class Query(ObjectType):
+    """Base class for GraphQL Query type."""
+
+    pass
+
+
+class Mutation(ObjectType):
+    """Base class for GraphQL Mutation type."""
+
+    pass
+
+
+class Subscription(ObjectType):
+    """Base class for GraphQL Subscription type."""
+
+    pass
+
+
+def graphql_type(cls: type) -> type:
+    """Register a class as a GraphQL type."""
+    graphql_object_type = cls.to_graphql_type()
+    _type_registry.register_type(cls.__name__, graphql_object_type)
+    return cls
+
+
+class GraphQLSchema:
+    """GraphQL schema builder for Velithon."""
+
+    def __init__(
+        self,
+        query: type[Query] | None = None,
+        mutation: type[Mutation] | None = None,
+        subscription: type[Subscription] | None = None,
+    ):
+        """Initialize GraphQL schema.
+
+        Args:
+            query: Query root type
+            mutation: Mutation root type
+            subscription: Subscription root type
+
+        """
+        self.query = query
+        self.mutation = mutation
+        self.subscription = subscription
+        self._schema: CoreGraphQLSchema | None = None
+
+    def build(self) -> CoreGraphQLSchema:
+        """Build the GraphQL schema."""
+        if self._schema is None:
+            schema_kwargs = {}
+
+            if self.query:
+                schema_kwargs['query'] = self.query.to_graphql_type()
+
+            if self.mutation:
+                schema_kwargs['mutation'] = self.mutation.to_graphql_type()
+
+            if self.subscription:
+                schema_kwargs['subscription'] = self.subscription.to_graphql_type()
+
+            self._schema = CoreGraphQLSchema(**schema_kwargs)
+
+            # Validate the schema
+            errors = validate_schema(self._schema)
+            if errors:
+                raise ValueError(f'Schema validation failed: {errors}')
+
+        return self._schema
+
+    def to_graphql_schema(self) -> CoreGraphQLSchema:
+        """Build the GraphQL schema (alias for build method)."""
+        return self.build()
+
+    def get_schema_sdl(self) -> str:
+        """Get the schema definition language (SDL) representation."""
+        return print_schema(self.build())

--- a/velithon/requests.py
+++ b/velithon/requests.py
@@ -134,10 +134,6 @@ class HTTPConnection(typing.Mapping[str, typing.Any]):
         """Return an iterator over the keys in the scope."""
         return iter(self.scope)
 
-    def __len__(self) -> int:
-        """Return the number of items in the scope."""
-        return len(self.scope)
-
     # Don't use the `abc.Mapping.__eq__` implementation.
     # Connection instances should never be considered equal
     # unless `self is other`.


### PR DESCRIPTION
- Introduced GraphQL endpoint handling with GET and POST support.
- Implemented GraphQL middleware for authentication and logging.
- Added GraphQL Playground for interactive API exploration.
- Created a schema definition system with support for queries, mutations, and subscriptions.
- Registered GraphQL types and fields with a type registry.
- Updated project dependencies to include `graphql-core`.